### PR TITLE
Implement Markdown-first chunking approach

### DIFF
--- a/rag_system/ingestion/chunker.py
+++ b/rag_system/ingestion/chunker.py
@@ -261,6 +261,98 @@ class SemanticChunker:
 
 
 # =============================================================================
+# Markdown-Based Chunking
+# =============================================================================
+
+def chunk_markdown(markdown: str,
+                   small_chunk_size: Optional[int] = None,
+                   large_chunk_size: Optional[int] = None,
+                   overlap: Optional[int] = None) -> Dict[str, List[Dict[str, Any]]]:
+    """Chunk Markdown text based on its heading structure.
+
+    This is the preferred chunking method as Markdown headings are unambiguous
+    content structure (unlike HTML where navigation headings can pollute results).
+
+    Args:
+        markdown: Markdown text to chunk.
+        small_chunk_size: Size for small chunks.
+        large_chunk_size: Size for large chunks.
+        overlap: Overlap between chunks.
+
+    Returns:
+        Dict with 'large_chunks' and 'small_chunks' lists.
+    """
+    from rag_system.ingestion.html_to_markdown import split_markdown_by_headings
+
+    if not markdown:
+        return {'large_chunks': [], 'small_chunks': []}
+
+    small_size = small_chunk_size or config.SMALL_CHUNK_SIZE
+    large_size = large_chunk_size or config.LARGE_CHUNK_SIZE
+    chunk_overlap = overlap or config.CHUNK_OVERLAP
+
+    # Split markdown by headings
+    sections = split_markdown_by_headings(markdown)
+
+    chunks = []
+    large_chunks = []
+    large_index = 0
+    small_index = 0
+
+    for section in sections:
+        section_content = section['content']
+        section_path = section['heading_path']
+
+        if not section_content.strip():
+            continue
+
+        # Create large chunks for this section
+        large_texts = chunk_text(section_content, large_size, chunk_overlap)
+
+        for content in large_texts:
+            if not content.strip():
+                continue
+
+            large_chunk = {
+                'type': 'large',
+                'content': content,
+                'index': large_index,
+                'heading_path': section_path,
+                'parent_index': None
+            }
+            large_chunks.append(large_chunk)
+            chunks.append(large_chunk)
+            large_index += 1
+
+    # Create small chunks linked to parent large chunks
+    for large_idx, large_chunk in enumerate(large_chunks):
+        small_texts = chunk_text(
+            large_chunk['content'],
+            small_size,
+            chunk_overlap // 2
+        )
+
+        for content in small_texts:
+            if not content.strip():
+                continue
+
+            chunk = {
+                'type': 'small',
+                'content': content,
+                'index': small_index,
+                'heading_path': large_chunk['heading_path'],
+                'parent_index': large_idx
+            }
+            chunks.append(chunk)
+            small_index += 1
+
+    return {
+        'large_chunks': [c for c in chunks if c['type'] == 'large'],
+        'small_chunks': [c for c in chunks if c['type'] == 'small']
+    }
+
+
+# =============================================================================
 # Main Function
 # =============================================================================
 

--- a/rag_system/ingestion/html_to_markdown.py
+++ b/rag_system/ingestion/html_to_markdown.py
@@ -1,0 +1,351 @@
+"""HTML to Markdown converter for the RAG system.
+
+Converts HTML content to clean Markdown, preserving semantic structure
+while stripping navigation, sidebars, and other non-content elements.
+Uses only Python standard library.
+"""
+
+import re
+from html.parser import HTMLParser
+from typing import List, Optional, Tuple
+
+
+class HTMLToMarkdownConverter(HTMLParser):
+    """Converts HTML to Markdown, focusing on content structure."""
+
+    # Tags that indicate non-content areas to skip entirely
+    SKIP_TAGS = {'nav', 'aside', 'footer', 'header', 'script', 'style', 'noscript', 'template'}
+
+    # Block-level tags that need newlines
+    BLOCK_TAGS = {
+        'p', 'div', 'section', 'article', 'main',
+        'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+        'ul', 'ol', 'li', 'dl', 'dt', 'dd',
+        'blockquote', 'pre', 'table', 'tr', 'th', 'td',
+        'br', 'hr'
+    }
+
+    # Heading tags mapped to markdown prefix
+    HEADING_MAP = {
+        'h1': '#',
+        'h2': '##',
+        'h3': '###',
+        'h4': '####',
+        'h5': '#####',
+        'h6': '######'
+    }
+
+    def __init__(self):
+        super().__init__()
+        self.output: List[str] = []
+        self.skip_depth = 0  # Track nested skip tags
+        self.tag_stack: List[str] = []
+        self.in_pre = False
+        self.in_code = False
+        self.in_list = False
+        self.list_type_stack: List[str] = []  # 'ul' or 'ol'
+        self.list_item_count_stack: List[int] = []
+        self.current_link_href: Optional[str] = None
+        self.link_text: List[str] = []
+        self.in_link = False
+
+    def handle_starttag(self, tag: str, attrs: List[Tuple[str, Optional[str]]]) -> None:
+        tag = tag.lower()
+        self.tag_stack.append(tag)
+        attrs_dict = dict(attrs)
+
+        # Skip non-content regions
+        if tag in self.SKIP_TAGS:
+            self.skip_depth += 1
+            return
+
+        if self.skip_depth > 0:
+            return
+
+        # Handle specific tags
+        if tag in self.HEADING_MAP:
+            self._add_newlines(2)
+            self.output.append(self.HEADING_MAP[tag] + ' ')
+
+        elif tag == 'p':
+            self._add_newlines(2)
+
+        elif tag == 'br':
+            self.output.append('\n')
+
+        elif tag == 'hr':
+            self._add_newlines(2)
+            self.output.append('---')
+            self._add_newlines(2)
+
+        elif tag == 'strong' or tag == 'b':
+            self.output.append('**')
+
+        elif tag == 'em' or tag == 'i':
+            self.output.append('*')
+
+        elif tag == 'code':
+            if not self.in_pre:
+                self.output.append('`')
+            self.in_code = True
+
+        elif tag == 'pre':
+            self._add_newlines(2)
+            self.output.append('```\n')
+            self.in_pre = True
+
+        elif tag == 'blockquote':
+            self._add_newlines(2)
+            self.output.append('> ')
+
+        elif tag == 'ul':
+            self._add_newlines(1)
+            self.list_type_stack.append('ul')
+            self.list_item_count_stack.append(0)
+            self.in_list = True
+
+        elif tag == 'ol':
+            self._add_newlines(1)
+            self.list_type_stack.append('ol')
+            self.list_item_count_stack.append(0)
+            self.in_list = True
+
+        elif tag == 'li':
+            self._add_newlines(1)
+            indent = '  ' * (len(self.list_type_stack) - 1)
+            if self.list_type_stack and self.list_type_stack[-1] == 'ol':
+                self.list_item_count_stack[-1] += 1
+                self.output.append(f'{indent}{self.list_item_count_stack[-1]}. ')
+            else:
+                self.output.append(f'{indent}- ')
+
+        elif tag == 'a':
+            href = attrs_dict.get('href', '')
+            if href and not href.startswith('#'):
+                self.current_link_href = href
+                self.in_link = True
+                self.link_text = []
+
+        elif tag == 'img':
+            alt = attrs_dict.get('alt', '')
+            src = attrs_dict.get('src', '')
+            if src:
+                self.output.append(f'![{alt}]({src})')
+
+        elif tag == 'table':
+            self._add_newlines(2)
+
+        elif tag == 'tr':
+            self._add_newlines(1)
+            self.output.append('| ')
+
+        elif tag == 'th' or tag == 'td':
+            pass  # Content handled in data
+
+        elif tag in self.BLOCK_TAGS:
+            self._add_newlines(1)
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+
+        # Pop from stack
+        if self.tag_stack and self.tag_stack[-1] == tag:
+            self.tag_stack.pop()
+
+        # Handle skip tags
+        if tag in self.SKIP_TAGS:
+            self.skip_depth = max(0, self.skip_depth - 1)
+            return
+
+        if self.skip_depth > 0:
+            return
+
+        # Handle specific closing tags
+        if tag in self.HEADING_MAP:
+            self._add_newlines(2)
+
+        elif tag == 'p':
+            self._add_newlines(2)
+
+        elif tag == 'strong' or tag == 'b':
+            self.output.append('**')
+
+        elif tag == 'em' or tag == 'i':
+            self.output.append('*')
+
+        elif tag == 'code':
+            if not self.in_pre:
+                self.output.append('`')
+            self.in_code = False
+
+        elif tag == 'pre':
+            self.output.append('\n```')
+            self._add_newlines(2)
+            self.in_pre = False
+
+        elif tag == 'blockquote':
+            self._add_newlines(2)
+
+        elif tag == 'ul' or tag == 'ol':
+            if self.list_type_stack:
+                self.list_type_stack.pop()
+            if self.list_item_count_stack:
+                self.list_item_count_stack.pop()
+            self.in_list = len(self.list_type_stack) > 0
+            self._add_newlines(1)
+
+        elif tag == 'a':
+            if self.in_link and self.current_link_href:
+                link_text = ''.join(self.link_text).strip()
+                if link_text:
+                    self.output.append(f'[{link_text}]({self.current_link_href})')
+            self.in_link = False
+            self.current_link_href = None
+            self.link_text = []
+
+        elif tag == 'th' or tag == 'td':
+            self.output.append(' | ')
+
+        elif tag == 'tr':
+            pass  # Row ended
+
+        elif tag == 'thead':
+            # Add markdown table header separator
+            self._add_newlines(1)
+            self.output.append('|---')
+
+    def handle_data(self, data: str) -> None:
+        if self.skip_depth > 0:
+            return
+
+        # Clean the text
+        if self.in_pre:
+            # Preserve whitespace in preformatted blocks
+            self.output.append(data)
+        else:
+            # Normalize whitespace
+            text = re.sub(r'\s+', ' ', data)
+            if text.strip():
+                if self.in_link:
+                    self.link_text.append(text)
+                else:
+                    self.output.append(text)
+
+    def _add_newlines(self, count: int) -> None:
+        """Add newlines, avoiding excessive blank lines."""
+        if not self.output:
+            return
+
+        # Count existing trailing newlines
+        existing = 0
+        for char in reversed(''.join(self.output)):
+            if char == '\n':
+                existing += 1
+            elif char == ' ':
+                continue
+            else:
+                break
+
+        # Add only the needed newlines
+        needed = max(0, count - existing)
+        if needed > 0:
+            self.output.append('\n' * needed)
+
+    def get_markdown(self) -> str:
+        """Get the converted Markdown text."""
+        text = ''.join(self.output)
+        # Clean up excessive whitespace
+        text = re.sub(r'\n{3,}', '\n\n', text)
+        text = re.sub(r'[ \t]+\n', '\n', text)
+        return text.strip()
+
+
+def html_to_markdown(html: str) -> str:
+    """Convert HTML to clean Markdown.
+
+    Extracts content from main/article/body, converts to Markdown format,
+    and strips navigation, sidebars, and other non-content elements.
+
+    Args:
+        html: HTML content to convert.
+
+    Returns:
+        Clean Markdown string.
+    """
+    converter = HTMLToMarkdownConverter()
+    try:
+        converter.feed(html)
+    except Exception:
+        # On parse error, return empty string
+        return ''
+    return converter.get_markdown()
+
+
+def extract_markdown_headings(markdown: str) -> List[dict]:
+    """Extract headings from Markdown text.
+
+    Args:
+        markdown: Markdown text.
+
+    Returns:
+        List of heading dicts with 'level', 'text', and 'position' keys.
+    """
+    headings = []
+    # Match markdown headings: # Heading, ## Heading, etc.
+    pattern = r'^(#{1,6})\s+(.+?)(?:\s*#*)?$'
+
+    for match in re.finditer(pattern, markdown, re.MULTILINE):
+        level = len(match.group(1))
+        text = match.group(2).strip()
+        headings.append({
+            'level': level,
+            'text': text,
+            'position': match.start()
+        })
+
+    return headings
+
+
+def split_markdown_by_headings(markdown: str) -> List[dict]:
+    """Split Markdown text into sections based on headings.
+
+    Args:
+        markdown: Markdown text.
+
+    Returns:
+        List of section dicts with 'content', 'heading', 'level', and 'heading_path'.
+    """
+    headings = extract_markdown_headings(markdown)
+
+    if not headings:
+        return [{'content': markdown, 'heading': '', 'level': 0, 'heading_path': ''}]
+
+    sections = []
+    heading_stack = {}  # level -> heading text
+
+    for i, heading in enumerate(headings):
+        start = heading['position']
+        end = headings[i + 1]['position'] if i + 1 < len(headings) else len(markdown)
+
+        content = markdown[start:end].strip()
+        level = heading['level']
+        text = heading['text']
+
+        # Update heading stack - clear lower levels when we see a higher level
+        for l in list(heading_stack.keys()):
+            if l >= level:
+                del heading_stack[l]
+        heading_stack[level] = text
+
+        # Build heading path from stack
+        path_parts = [heading_stack[l] for l in sorted(heading_stack.keys())]
+        heading_path = ' > '.join(path_parts)
+
+        sections.append({
+            'content': content,
+            'heading': text,
+            'level': level,
+            'heading_path': heading_path
+        })
+
+    return sections

--- a/rag_system/ingestion/indexer.py
+++ b/rag_system/ingestion/indexer.py
@@ -14,7 +14,8 @@ from rag_system.database import (
 )
 from rag_system.ingestion.crawler import Crawler
 from rag_system.ingestion.parser import parse_html, extract_title
-from rag_system.ingestion.chunker import chunk_document
+from rag_system.ingestion.chunker import chunk_markdown
+from rag_system.ingestion.html_to_markdown import html_to_markdown
 from rag_system.utils import hash_content, get_logger
 
 logger = get_logger(__name__)
@@ -63,8 +64,13 @@ class Indexer:
                 logger.info(f"Page exists, skipping: {url}")
                 return existing['id']
 
-            # Parse HTML
+            # Parse HTML for title and basic text
             parsed = parse_html(html, remove_nav=True, remove_footer=True)
+
+            # Convert HTML to Markdown for chunking (Markdown-first approach)
+            # This naturally filters out nav/sidebar/footer as they don't convert
+            # to meaningful Markdown structure
+            markdown = html_to_markdown(html)
 
             # Generate content hash
             content_hash = hash_content(html)
@@ -75,16 +81,15 @@ class Indexer:
                 url=url,
                 title=parsed['title'] or extract_title(html),
                 raw_html=html,
-                parsed_text=parsed['text'],
+                parsed_text=markdown,  # Store markdown instead of parsed text
                 content_hash=content_hash
             )
 
             logger.info(f"Indexed page: {url} (id={page_id})")
 
-            # Create chunks
-            chunk_result = chunk_document(
-                text=parsed['text'],
-                headings=parsed['headings'],
+            # Create chunks from Markdown (heading structure is unambiguous in MD)
+            chunk_result = chunk_markdown(
+                markdown=markdown,
                 small_chunk_size=config.SMALL_CHUNK_SIZE,
                 large_chunk_size=config.LARGE_CHUNK_SIZE,
                 overlap=config.CHUNK_OVERLAP

--- a/rag_system/ingestion/parser.py
+++ b/rag_system/ingestion/parser.py
@@ -101,28 +101,21 @@ class TextExtractor(HTMLParser):
 # =============================================================================
 
 class HeadingExtractor(HTMLParser):
-    """HTML parser that extracts headings."""
+    """HTML parser that extracts headings.
+
+    Note: This extracts ALL headings from HTML without filtering.
+    For chunking, we use the Markdown-first approach (html_to_markdown.py)
+    which naturally filters out navigation/sidebar headings by only
+    converting content structure to Markdown.
+    """
 
     HEADING_TAGS = {'h1', 'h2', 'h3', 'h4', 'h5', 'h6'}
-
-    # Common UI/navigation headings to ignore (case-insensitive)
-    IGNORE_HEADINGS = {
-        'navigation', 'table of contents', 'contents', 'toc',
-        'previous topic', 'next topic', 'this page',
-        'quick search', 'search', 'menu', 'sidebar',
-        'related topics', 'see also', 'footer', 'header',
-    }
 
     def __init__(self):
         super().__init__()
         self.headings: List[Dict[str, Any]] = []
         self.current_heading: Optional[Dict[str, Any]] = None
         self.current_text: List[str] = []
-
-    def _is_ignored_heading(self, text: str) -> bool:
-        """Check if heading text should be ignored."""
-        normalized = text.lower().strip()
-        return normalized in self.IGNORE_HEADINGS
 
     def handle_starttag(self, tag: str, attrs: List[tuple]) -> None:
         tag = tag.lower()
@@ -135,8 +128,8 @@ class HeadingExtractor(HTMLParser):
         tag = tag.lower()
         if tag in self.HEADING_TAGS and self.current_heading:
             self.current_heading['text'] = ' '.join(self.current_text).strip()
-            # Only add if non-empty and not an ignored UI heading
-            if self.current_heading['text'] and not self._is_ignored_heading(self.current_heading['text']):
+            # Add all non-empty headings (no filtering - let Markdown conversion handle it)
+            if self.current_heading['text']:
                 self.headings.append(self.current_heading)
             self.current_heading = None
             self.current_text = []

--- a/tests/test_html_to_markdown.py
+++ b/tests/test_html_to_markdown.py
@@ -1,0 +1,353 @@
+"""Tests for the html_to_markdown module."""
+
+import unittest
+
+
+class TestHTMLToMarkdownConverter(unittest.TestCase):
+    """Test HTML to Markdown conversion."""
+
+    def test_basic_paragraph(self):
+        """html_to_markdown should convert paragraphs."""
+        from rag_system.ingestion.html_to_markdown import html_to_markdown
+
+        html = '<html><body><p>Hello world</p></body></html>'
+        result = html_to_markdown(html)
+
+        self.assertIn('Hello world', result)
+
+    def test_headings_conversion(self):
+        """html_to_markdown should convert headings to markdown format."""
+        from rag_system.ingestion.html_to_markdown import html_to_markdown
+
+        html = '''
+        <html><body>
+            <h1>Main Title</h1>
+            <h2>Section</h2>
+            <h3>Subsection</h3>
+        </body></html>
+        '''
+        result = html_to_markdown(html)
+
+        self.assertIn('# Main Title', result)
+        self.assertIn('## Section', result)
+        self.assertIn('### Subsection', result)
+
+    def test_skips_nav_elements(self):
+        """html_to_markdown should skip content in nav elements."""
+        from rag_system.ingestion.html_to_markdown import html_to_markdown
+
+        html = '''
+        <html><body>
+            <nav><h3>Navigation</h3><a href="/">Home</a></nav>
+            <main><h1>Real Content</h1><p>This is the content.</p></main>
+        </body></html>
+        '''
+        result = html_to_markdown(html)
+
+        self.assertNotIn('Navigation', result)
+        self.assertNotIn('Home', result)
+        self.assertIn('# Real Content', result)
+        self.assertIn('This is the content', result)
+
+    def test_skips_aside_elements(self):
+        """html_to_markdown should skip content in aside elements."""
+        from rag_system.ingestion.html_to_markdown import html_to_markdown
+
+        html = '''
+        <html><body>
+            <aside><h4>Sidebar</h4><p>Side content</p></aside>
+            <article><h1>Article</h1><p>Main content</p></article>
+        </body></html>
+        '''
+        result = html_to_markdown(html)
+
+        self.assertNotIn('Sidebar', result)
+        self.assertNotIn('Side content', result)
+        self.assertIn('# Article', result)
+        self.assertIn('Main content', result)
+
+    def test_skips_footer_elements(self):
+        """html_to_markdown should skip content in footer elements."""
+        from rag_system.ingestion.html_to_markdown import html_to_markdown
+
+        html = '''
+        <html><body>
+            <main><h1>Content</h1><p>Main text</p></main>
+            <footer><p>Copyright 2024</p></footer>
+        </body></html>
+        '''
+        result = html_to_markdown(html)
+
+        self.assertIn('# Content', result)
+        self.assertIn('Main text', result)
+        self.assertNotIn('Copyright', result)
+
+    def test_skips_header_elements(self):
+        """html_to_markdown should skip content in header elements."""
+        from rag_system.ingestion.html_to_markdown import html_to_markdown
+
+        html = '''
+        <html><body>
+            <header><h1>Site Title</h1></header>
+            <main><h1>Page Title</h1><p>Content here</p></main>
+        </body></html>
+        '''
+        result = html_to_markdown(html)
+
+        self.assertNotIn('Site Title', result)
+        self.assertIn('# Page Title', result)
+        self.assertIn('Content here', result)
+
+    def test_bold_and_italic(self):
+        """html_to_markdown should convert bold and italic."""
+        from rag_system.ingestion.html_to_markdown import html_to_markdown
+
+        html = '<p>This is <strong>bold</strong> and <em>italic</em>.</p>'
+        result = html_to_markdown(html)
+
+        self.assertIn('**bold**', result)
+        self.assertIn('*italic*', result)
+
+    def test_inline_code(self):
+        """html_to_markdown should convert inline code."""
+        from rag_system.ingestion.html_to_markdown import html_to_markdown
+
+        html = '<p>Use <code>print()</code> to output.</p>'
+        result = html_to_markdown(html)
+
+        self.assertIn('`print()`', result)
+
+    def test_code_blocks(self):
+        """html_to_markdown should convert code blocks."""
+        from rag_system.ingestion.html_to_markdown import html_to_markdown
+
+        html = '<pre><code>def hello():\n    print("Hi")</code></pre>'
+        result = html_to_markdown(html)
+
+        self.assertIn('```', result)
+        self.assertIn('def hello():', result)
+
+    def test_unordered_lists(self):
+        """html_to_markdown should convert unordered lists."""
+        from rag_system.ingestion.html_to_markdown import html_to_markdown
+
+        html = '<ul><li>Item 1</li><li>Item 2</li></ul>'
+        result = html_to_markdown(html)
+
+        self.assertIn('- Item 1', result)
+        self.assertIn('- Item 2', result)
+
+    def test_ordered_lists(self):
+        """html_to_markdown should convert ordered lists."""
+        from rag_system.ingestion.html_to_markdown import html_to_markdown
+
+        html = '<ol><li>First</li><li>Second</li></ol>'
+        result = html_to_markdown(html)
+
+        self.assertIn('1. First', result)
+        self.assertIn('2. Second', result)
+
+    def test_links(self):
+        """html_to_markdown should convert links."""
+        from rag_system.ingestion.html_to_markdown import html_to_markdown
+
+        html = '<p>Visit <a href="https://example.com">Example</a>.</p>'
+        result = html_to_markdown(html)
+
+        self.assertIn('[Example](https://example.com)', result)
+
+    def test_skips_script_and_style(self):
+        """html_to_markdown should skip script and style elements."""
+        from rag_system.ingestion.html_to_markdown import html_to_markdown
+
+        html = '''
+        <html>
+        <head><style>.hidden { display: none; }</style></head>
+        <body>
+            <script>alert("hi");</script>
+            <p>Visible content</p>
+        </body></html>
+        '''
+        result = html_to_markdown(html)
+
+        self.assertNotIn('display: none', result)
+        self.assertNotIn('alert', result)
+        self.assertIn('Visible content', result)
+
+    def test_empty_html(self):
+        """html_to_markdown should handle empty HTML."""
+        from rag_system.ingestion.html_to_markdown import html_to_markdown
+
+        result = html_to_markdown('')
+
+        self.assertEqual(result, '')
+
+
+class TestExtractMarkdownHeadings(unittest.TestCase):
+    """Test Markdown heading extraction."""
+
+    def test_extracts_all_heading_levels(self):
+        """extract_markdown_headings should find all heading levels."""
+        from rag_system.ingestion.html_to_markdown import extract_markdown_headings
+
+        markdown = '''# H1
+## H2
+### H3
+#### H4
+##### H5
+###### H6
+'''
+        headings = extract_markdown_headings(markdown)
+
+        self.assertEqual(len(headings), 6)
+        self.assertEqual(headings[0]['level'], 1)
+        self.assertEqual(headings[0]['text'], 'H1')
+        self.assertEqual(headings[5]['level'], 6)
+        self.assertEqual(headings[5]['text'], 'H6')
+
+    def test_includes_position(self):
+        """extract_markdown_headings should include heading position."""
+        from rag_system.ingestion.html_to_markdown import extract_markdown_headings
+
+        markdown = '''Some intro text.
+
+# First Heading
+
+Content here.
+
+## Second Heading
+'''
+        headings = extract_markdown_headings(markdown)
+
+        self.assertEqual(len(headings), 2)
+        self.assertGreater(headings[0]['position'], 0)
+        self.assertGreater(headings[1]['position'], headings[0]['position'])
+
+    def test_no_headings(self):
+        """extract_markdown_headings should handle text with no headings."""
+        from rag_system.ingestion.html_to_markdown import extract_markdown_headings
+
+        markdown = 'Just plain text with no headings.'
+        headings = extract_markdown_headings(markdown)
+
+        self.assertEqual(len(headings), 0)
+
+
+class TestSplitMarkdownByHeadings(unittest.TestCase):
+    """Test Markdown section splitting."""
+
+    def test_splits_by_headings(self):
+        """split_markdown_by_headings should split at heading boundaries."""
+        from rag_system.ingestion.html_to_markdown import split_markdown_by_headings
+
+        markdown = '''# Introduction
+
+This is the intro.
+
+## Getting Started
+
+Start here.
+
+## Advanced Topics
+
+More complex stuff.
+'''
+        sections = split_markdown_by_headings(markdown)
+
+        self.assertEqual(len(sections), 3)
+        self.assertEqual(sections[0]['heading'], 'Introduction')
+        self.assertEqual(sections[1]['heading'], 'Getting Started')
+        self.assertEqual(sections[2]['heading'], 'Advanced Topics')
+
+    def test_builds_heading_paths(self):
+        """split_markdown_by_headings should build hierarchical heading paths."""
+        from rag_system.ingestion.html_to_markdown import split_markdown_by_headings
+
+        markdown = '''# Main
+
+## Section A
+
+### Subsection A1
+
+## Section B
+'''
+        sections = split_markdown_by_headings(markdown)
+
+        self.assertEqual(sections[0]['heading_path'], 'Main')
+        self.assertEqual(sections[1]['heading_path'], 'Main > Section A')
+        self.assertEqual(sections[2]['heading_path'], 'Main > Section A > Subsection A1')
+        self.assertEqual(sections[3]['heading_path'], 'Main > Section B')
+
+    def test_no_headings_returns_single_section(self):
+        """split_markdown_by_headings should return one section for no headings."""
+        from rag_system.ingestion.html_to_markdown import split_markdown_by_headings
+
+        markdown = 'Just plain text with no headings.'
+        sections = split_markdown_by_headings(markdown)
+
+        self.assertEqual(len(sections), 1)
+        self.assertEqual(sections[0]['content'], markdown)
+        self.assertEqual(sections[0]['heading_path'], '')
+
+
+class TestMarkdownChunking(unittest.TestCase):
+    """Test the full Markdown chunking pipeline."""
+
+    def test_chunk_markdown_creates_chunks(self):
+        """chunk_markdown should create large and small chunks."""
+        from rag_system.ingestion.chunker import chunk_markdown
+
+        markdown = '''# Introduction
+
+This is a fairly long introduction that goes on and on with lots of text
+to ensure we get multiple chunks out of it. We need enough content here
+to exceed the chunk size limits. Let me add more text to make this work.
+More and more text keeps flowing to build up the content size.
+
+## Getting Started
+
+Here we have another section with plenty of content to chunk.
+This section also needs to be long enough to create multiple chunks.
+Adding more sentences to bulk up the content for testing purposes.
+'''
+        result = chunk_markdown(markdown, small_chunk_size=100, large_chunk_size=200, overlap=20)
+
+        self.assertIn('large_chunks', result)
+        self.assertIn('small_chunks', result)
+        self.assertGreater(len(result['large_chunks']), 0)
+        self.assertGreater(len(result['small_chunks']), 0)
+
+    def test_chunk_markdown_preserves_heading_paths(self):
+        """chunk_markdown should assign correct heading paths to chunks."""
+        from rag_system.ingestion.chunker import chunk_markdown
+
+        markdown = '''# Main Title
+
+Content for main.
+
+## Section One
+
+Content for section one with enough text to create a chunk.
+'''
+        result = chunk_markdown(markdown, small_chunk_size=50, large_chunk_size=100, overlap=10)
+
+        # Check that chunks have heading paths
+        for chunk in result['large_chunks']:
+            self.assertIn('heading_path', chunk)
+
+        # First section should have "Main Title" in path
+        paths = [c['heading_path'] for c in result['large_chunks']]
+        self.assertTrue(any('Main Title' in p for p in paths))
+
+    def test_chunk_markdown_empty_input(self):
+        """chunk_markdown should handle empty input."""
+        from rag_system.ingestion.chunker import chunk_markdown
+
+        result = chunk_markdown('')
+
+        self.assertEqual(result['large_chunks'], [])
+        self.assertEqual(result['small_chunks'], [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -200,6 +200,46 @@ class TestCrawlAndIndex(unittest.TestCase):
         self.assertEqual(len(all_pages), 2)
         self.assertEqual(stats['pages_indexed'], 2)
 
+    def test_bm25_index_built_after_crawl(self):
+        """crawl_and_index should build BM25 index after indexing pages."""
+        from rag_system.ingestion.indexer import Indexer
+        from rag_system.ingestion.crawler import Crawler
+        from rag_system.database import get_connection
+
+        mock_pages = [
+            {'url': 'https://example.com/', 'html': '<html><body>Home page content</body></html>', 'status_code': 200},
+            {'url': 'https://example.com/about', 'html': '<html><body>About page content</body></html>', 'status_code': 200},
+        ]
+
+        indexer = Indexer(self.temp_path)
+
+        with patch.object(Crawler, 'crawl', return_value=iter(mock_pages)):
+            stats = indexer.crawl_and_index(
+                start_url='https://example.com',
+                allowed_domains=['example.com'],
+                max_pages=10
+            )
+
+        # Verify BM25 index tables are populated
+        conn = get_connection(self.temp_path)
+
+        # Check doc_terms table
+        cursor = conn.execute("SELECT COUNT(*) as count FROM doc_terms")
+        doc_terms_count = cursor.fetchone()['count']
+        self.assertGreater(doc_terms_count, 0, "doc_terms table should have entries")
+
+        # Check corpus_stats table
+        cursor = conn.execute("SELECT COUNT(*) as count FROM corpus_stats")
+        corpus_stats_count = cursor.fetchone()['count']
+        self.assertEqual(corpus_stats_count, 1, "corpus_stats should have one row")
+
+        # Check term_doc_frequencies table
+        cursor = conn.execute("SELECT COUNT(*) as count FROM term_doc_frequencies")
+        term_freq_count = cursor.fetchone()['count']
+        self.assertGreater(term_freq_count, 0, "term_doc_frequencies should have unique terms")
+
+        conn.close()
+
 
 class TestIndexStats(unittest.TestCase):
     """Test index statistics functionality."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -81,6 +81,38 @@ class TestRAGSystem(unittest.TestCase):
         self.assertEqual(stats['pages'], 1)
         self.assertEqual(stats['chunks'], 1)
 
+    def test_ingest_with_mocked_crawler(self):
+        """ingest should call crawl_and_index with correct parameters."""
+        from rag_system.main import RAGSystem
+        from rag_system.ingestion.indexer import Indexer
+
+        rag = RAGSystem(db_path=self.temp_path)
+
+        # Mock crawl_and_index to verify it's called correctly
+        with patch.object(Indexer, 'crawl_and_index') as mock_crawl:
+            mock_crawl.return_value = {
+                'pages_crawled': 5,
+                'pages_indexed': 4,
+                'pages_skipped': 1,
+                'errors': 0
+            }
+
+            stats = rag.ingest('https://docs.python.org/3.6/', max_pages=5)
+
+            # Verify crawl_and_index was called
+            self.assertTrue(mock_crawl.called)
+
+            # Verify parameters passed correctly
+            call_args = mock_crawl.call_args
+            self.assertEqual(call_args[1]['start_url'], 'https://docs.python.org/3.6/')
+            self.assertIn('allowed_domains', call_args[1])
+            self.assertEqual(call_args[1]['allowed_domains'], ['docs.python.org'])
+            self.assertEqual(call_args[1]['max_pages'], 5)
+
+            # Verify stats returned
+            self.assertEqual(stats['pages_crawled'], 5)
+            self.assertEqual(stats['pages_indexed'], 4)
+
 
 class TestCLICommands(unittest.TestCase):
     """Test CLI command handling."""
@@ -172,6 +204,39 @@ class TestResultFormatting(unittest.TestCase):
         self.assertIn('10', formatted)
         self.assertIn('100', formatted)
         self.assertIn('50', formatted)
+
+
+class TestIngestOutput(unittest.TestCase):
+    """Test ingestion output formatting."""
+
+    def test_stats_printed_correctly(self):
+        """main() should print correct stats after ingestion."""
+        from rag_system.main import main
+        import sys
+        from io import StringIO
+
+        # Mock sys.argv for CLI
+        test_args = ['rag_system', 'ingest', 'https://example.com', '--max-pages', '5']
+
+        # Mock RAGSystem.ingest to return stats
+        mock_stats = {
+            'pages_crawled': 10,
+            'pages_indexed': 8,
+            'pages_skipped': 2,
+            'errors': 0
+        }
+
+        with patch('sys.argv', test_args), \
+             patch('rag_system.main.RAGSystem.ingest', return_value=mock_stats), \
+             patch('sys.stdout', new=StringIO()) as fake_out:
+
+            main()
+            output = fake_out.getvalue()
+
+            # Verify output contains correct numbers
+            self.assertIn('Crawled 10 pages', output)  # pages_crawled
+            self.assertIn('indexed 8', output)   # pages_indexed
+            self.assertNotIn('Ingested 0 pages', output)  # Bug 2 check - old buggy format
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- Add `html_to_markdown.py` module that converts HTML to clean Markdown, filtering nav/aside/footer/header/script/style elements
- Add `chunk_markdown()` function for chunking based on Markdown heading structure
- Update indexer to use Markdown-first approach for better heading path accuracy
- Remove hardcoded `IGNORE_HEADINGS` filter from parser (no longer needed)
- Add comprehensive tests for HTML-to-Markdown conversion (353 lines of test coverage)

## Why Markdown-First?

The Markdown-first approach is general-purpose and doesn't require site-specific text patterns. Navigation filtering relies on semantic HTML tags (`<nav>`, `<aside>`, `<footer>`, etc.), making it work across any well-structured website. Markdown headings are unambiguous content structure—unlike HTML where navigation headings can pollute search results.

## Test plan

- [x] All 323 unit tests pass
- [x] Manual verification of HTML→Markdown conversion (nav/footer correctly filtered)
- [x] Manual verification of heading path generation (hierarchical paths like "Config > Database > Pool")
- [x] Manual verification of parent-child chunk relationships

🤖 Generated with [Claude Code](https://claude.com/claude-code)