### PR TITLE
Issue #15: API client error handling and circuit breaker

### DIFF
--- a/rag_system/api_client.py
+++ b/rag_system/api_client.py
@@ -3,6 +3,7 @@
 Provides wrappers for vector embedding and chat completion APIs.
 Includes OpenAI-compatible clients for use with OpenAI's API.
 Uses only Python standard library (urllib).
+Includes circuit breaker pattern for fault tolerance.
 """
 
 import json
@@ -10,12 +11,21 @@ import os
 import re
 import ssl
 import time
+import threading
 import urllib.request
 import urllib.error
-from typing import List, Optional, Dict, Any, Union
+from typing import List, Optional, Dict, Any, Union, Callable, TypeVar
+from functools import wraps
 
 from rag_system import config
 
+# Type variable for generic decorator
+T = TypeVar('T')
+
+
+# =============================================================================
+# Custom Exceptions
+# =============================================================================
 
 class APIError(Exception):
     """Exception raised when an API call fails."""
@@ -27,9 +37,156 @@ class APIError(Exception):
         self.response = response
 
 
+class CircuitBreakerError(APIError):
+    """Exception raised when circuit breaker is open."""
+
+    def __init__(self, message: str = "Circuit breaker is open"):
+        super().__init__(message)
+
+
+class TimeoutError(APIError):
+    """Exception raised when API request times out."""
+
+    def __init__(self, message: str = "API request timed out"):
+        super().__init__(message)
+
+
+# =============================================================================
+# Circuit Breaker Implementation
+# =============================================================================
+
+class CircuitBreaker:
+    """Circuit breaker implementation for fault tolerance.
+
+    The circuit breaker has three states:
+    - CLOSED: Normal operation, requests pass through
+    - OPEN: Failing, requests blocked immediately
+    - HALF_OPEN: Testing, allowing a single request through
+
+    After failure_threshold consecutive failures, the circuit opens.
+    After reset_timeout seconds, the circuit enters half-open state.
+    A successful request in half-open state closes the circuit.
+    """
+
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+    def __init__(self, failure_threshold: int = 5, reset_timeout: float = 60.0,
+                 name: str = "default"):
+        """Initialize the circuit breaker.
+
+        Args:
+            failure_threshold: Number of consecutive failures before opening.
+            reset_timeout: Seconds to wait before half-open state.
+            name: Name for logging/identification.
+        """
+        self.failure_threshold = failure_threshold
+        self.reset_timeout = reset_timeout
+        self.name = name
+
+        self._state = self.CLOSED
+        self._failure_count = 0
+        self._last_failure_time: Optional[float] = None
+        self._lock = threading.Lock()
+
+    @property
+    def state(self) -> str:
+        """Get current circuit state."""
+        with self._lock:
+            if self._state == self.OPEN:
+                # Check if we should transition to half-open
+                if (self._last_failure_time and
+                    time.time() - self._last_failure_time >= self.reset_timeout):
+                    self._state = self.HALF_OPEN
+            return self._state
+
+    def record_success(self) -> None:
+        """Record a successful call."""
+        with self._lock:
+            self._failure_count = 0
+            self._state = self.CLOSED
+
+    def record_failure(self) -> None:
+        """Record a failed call."""
+        with self._lock:
+            self._failure_count += 1
+            self._last_failure_time = time.time()
+            if self._failure_count >= self.failure_threshold:
+                self._state = self.OPEN
+
+    def can_execute(self) -> bool:
+        """Check if a request can be executed."""
+        current_state = self.state
+        return current_state in (self.CLOSED, self.HALF_OPEN)
+
+    def reset(self) -> None:
+        """Reset the circuit breaker to closed state."""
+        with self._lock:
+            self._state = self.CLOSED
+            self._failure_count = 0
+            self._last_failure_time = None
+
+
+def with_circuit_breaker(circuit_breaker: CircuitBreaker) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """Decorator to wrap a function with circuit breaker protection.
+
+    Args:
+        circuit_breaker: CircuitBreaker instance to use.
+
+    Returns:
+        Decorated function.
+    """
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            if not circuit_breaker.can_execute():
+                raise CircuitBreakerError(
+                    f"Circuit breaker '{circuit_breaker.name}' is open - "
+                    f"API unavailable after {circuit_breaker.failure_threshold} failures"
+                )
+            try:
+                result = func(*args, **kwargs)
+                circuit_breaker.record_success()
+                return result
+            except Exception as e:
+                circuit_breaker.record_failure()
+                raise
+        return wrapper
+    return decorator
+
+
+# Global circuit breakers for API clients
+_vector_api_circuit_breaker = CircuitBreaker(
+    failure_threshold=5,
+    reset_timeout=60.0,
+    name="vector_api"
+)
+
+_chat_api_circuit_breaker = CircuitBreaker(
+    failure_threshold=5,
+    reset_timeout=60.0,
+    name="chat_api"
+)
+
+
+def get_vector_circuit_breaker() -> CircuitBreaker:
+    """Get the global vector API circuit breaker."""
+    return _vector_api_circuit_breaker
+
+
+def get_chat_circuit_breaker() -> CircuitBreaker:
+    """Get the global chat API circuit breaker."""
+    return _chat_api_circuit_breaker
+
+
 # =============================================================================
 # Shared HTTP Utilities
 # =============================================================================
+
+# Default timeout for API requests (seconds)
+DEFAULT_TIMEOUT: float = 30.0
+
 
 def create_ssl_context(ssl_verify: bool, ssl_cert_path: Optional[str]) -> Optional[ssl.SSLContext]:
     """Create SSL context for HTTPS requests.
@@ -57,38 +214,51 @@ def create_ssl_context(ssl_verify: bool, ssl_cert_path: Optional[str]) -> Option
 
 def make_http_request(endpoint: str, data: Dict[str, Any], headers: Dict[str, str],
                       ssl_context: Optional[ssl.SSLContext] = None,
-                      max_retries: int = 3) -> Dict[str, Any]:
+                      max_retries: int = 3,
+                      timeout: float = DEFAULT_TIMEOUT) -> Dict[str, Any]:
     """Make an HTTP POST request and return parsed JSON.
 
-    Automatically retries on rate limit (429) errors with exponential backoff.
+    Automatically retries on rate limit (429) and server error (5xx) codes
+    with exponential backoff.
 
     Args:
         endpoint: API endpoint URL.
         data: Request body data.
         headers: HTTP headers.
         ssl_context: Optional SSL context.
-        max_retries: Maximum number of retries for rate limit errors.
+        max_retries: Maximum number of retries for transient errors.
+        timeout: Request timeout in seconds.
 
     Returns:
         Parsed JSON response.
 
     Raises:
         APIError: If the request fails after all retries.
+        TimeoutError: If the request times out.
     """
     body = json.dumps(data).encode('utf-8')
+
+    # Retryable status codes
+    retryable_codes = {429, 500, 502, 503, 504}
 
     for attempt in range(max_retries + 1):
         request = urllib.request.Request(endpoint, data=body, headers=headers, method='POST')
 
         try:
-            with urllib.request.urlopen(request, context=ssl_context) as response:
+            with urllib.request.urlopen(request, context=ssl_context, timeout=timeout) as response:
                 response_data = response.read().decode('utf-8')
-                return json.loads(response_data)
+                try:
+                    return json.loads(response_data)
+                except json.JSONDecodeError as e:
+                    raise APIError(
+                        f"Failed to parse API response as JSON: {e}",
+                        response=response_data[:500] if response_data else None
+                    )
         except urllib.error.HTTPError as e:
-            # Handle rate limiting with retry
-            if e.code == 429 and attempt < max_retries:
+            # Check if this is a retryable error
+            if e.code in retryable_codes and attempt < max_retries:
                 # Try to get Retry-After header, default to exponential backoff
-                retry_after = e.headers.get('Retry-After')
+                retry_after = e.headers.get('Retry-After') if e.headers else None
                 if retry_after:
                     try:
                         delay = int(retry_after)
@@ -99,20 +269,56 @@ def make_http_request(endpoint: str, data: Dict[str, Any], headers: Dict[str, st
                 time.sleep(delay)
                 continue
 
+            # Read error response safely
+            error_response = None
+            try:
+                if hasattr(e, 'read') and callable(e.read):
+                    error_response = e.read().decode('utf-8')
+            except Exception:
+                pass  # Ignore errors reading the error response
+
             raise APIError(
                 f"API request failed: {e.reason}",
                 status_code=e.code,
-                response=e.read().decode('utf-8') if e.fp else None
+                response=error_response
             )
         except urllib.error.URLError as e:
+            # Check if it's a timeout
+            if 'timed out' in str(e.reason).lower():
+                if attempt < max_retries:
+                    time.sleep(2 ** attempt)
+                    continue
+                raise TimeoutError(f"API request timed out after {timeout}s")
+
+            # Other URL errors (network issues, etc.)
+            if attempt < max_retries:
+                time.sleep(2 ** attempt)
+                continue
+
             raise APIError(f"API request failed: {e.reason}")
+        except Exception as e:
+            # Catch socket timeout and other unexpected errors
+            if 'timed out' in str(e).lower():
+                if attempt < max_retries:
+                    time.sleep(2 ** attempt)
+                    continue
+                raise TimeoutError(f"API request timed out after {timeout}s")
+            raise APIError(f"Unexpected error during API request: {e}")
+
+    # Should not reach here, but satisfy type checker
+    raise APIError("API request failed after all retries")
 
 
 class VectorAPIClient:
-    """Client for vector embedding API."""
+    """Client for vector embedding API.
+
+    Uses circuit breaker pattern to prevent cascading failures.
+    """
 
     def __init__(self, endpoint: str, auth_header: str, auth_value: str,
-                 ssl_verify: bool = True, ssl_cert_path: Optional[str] = None):
+                 ssl_verify: bool = True, ssl_cert_path: Optional[str] = None,
+                 timeout: float = DEFAULT_TIMEOUT,
+                 circuit_breaker: Optional[CircuitBreaker] = None):
         """Initialize the vector API client.
 
         Args:
@@ -121,19 +327,43 @@ class VectorAPIClient:
             auth_value: Value for the authentication header.
             ssl_verify: Whether to verify SSL certificates.
             ssl_cert_path: Path to SSL certificate file.
+            timeout: Request timeout in seconds.
+            circuit_breaker: Optional circuit breaker (uses global if not provided).
         """
         self.endpoint = endpoint
         self.auth_header = auth_header
         self.auth_value = auth_value
         self.ssl_context = create_ssl_context(ssl_verify, ssl_cert_path)
+        self.timeout = timeout
+        self._circuit_breaker = circuit_breaker or get_vector_circuit_breaker()
 
     def _make_request(self, data: Dict[str, Any]) -> Dict[str, Any]:
-        """Make an HTTP request to the API."""
+        """Make an HTTP request to the API.
+
+        Raises:
+            CircuitBreakerError: If circuit breaker is open.
+            APIError: If request fails.
+        """
+        if not self._circuit_breaker.can_execute():
+            raise CircuitBreakerError(
+                f"Vector API circuit breaker is open - "
+                f"service unavailable after consecutive failures"
+            )
+
         headers = {
             'Content-Type': 'application/json',
             self.auth_header: self.auth_value
         }
-        return make_http_request(self.endpoint, data, headers, self.ssl_context)
+
+        try:
+            result = make_http_request(
+                self.endpoint, data, headers, self.ssl_context, timeout=self.timeout
+            )
+            self._circuit_breaker.record_success()
+            return result
+        except APIError:
+            self._circuit_breaker.record_failure()
+            raise
 
     def get_embedding(self, text: str) -> List[float]:
         """Get embedding for a single text.
@@ -146,6 +376,7 @@ class VectorAPIClient:
 
         Raises:
             APIError: If the request fails.
+            CircuitBreakerError: If circuit breaker is open.
         """
         response = self._make_request({'text': text})
         return response.get('embedding', [])
@@ -161,16 +392,30 @@ class VectorAPIClient:
 
         Raises:
             APIError: If the request fails.
+            CircuitBreakerError: If circuit breaker is open.
         """
         response = self._make_request({'texts': texts})
         return response.get('embeddings', [])
 
+    def is_available(self) -> bool:
+        """Check if the API is available (circuit breaker closed/half-open)."""
+        return self._circuit_breaker.can_execute()
+
+    def reset_circuit_breaker(self) -> None:
+        """Reset the circuit breaker to allow requests again."""
+        self._circuit_breaker.reset()
+
 
 class ChatAPIClient:
-    """Client for chat completion API."""
+    """Client for chat completion API.
+
+    Uses circuit breaker pattern to prevent cascading failures.
+    """
 
     def __init__(self, endpoint: str, auth_header: str, auth_value: str,
-                 ssl_verify: bool = True, ssl_cert_path: Optional[str] = None):
+                 ssl_verify: bool = True, ssl_cert_path: Optional[str] = None,
+                 timeout: float = DEFAULT_TIMEOUT,
+                 circuit_breaker: Optional[CircuitBreaker] = None):
         """Initialize the chat API client.
 
         Args:
@@ -179,19 +424,43 @@ class ChatAPIClient:
             auth_value: Value for the authentication header.
             ssl_verify: Whether to verify SSL certificates.
             ssl_cert_path: Path to SSL certificate file.
+            timeout: Request timeout in seconds.
+            circuit_breaker: Optional circuit breaker (uses global if not provided).
         """
         self.endpoint = endpoint
         self.auth_header = auth_header
         self.auth_value = auth_value
         self.ssl_context = create_ssl_context(ssl_verify, ssl_cert_path)
+        self.timeout = timeout
+        self._circuit_breaker = circuit_breaker or get_chat_circuit_breaker()
 
     def _make_request(self, data: Dict[str, Any]) -> Dict[str, Any]:
-        """Make an HTTP request to the API."""
+        """Make an HTTP request to the API.
+
+        Raises:
+            CircuitBreakerError: If circuit breaker is open.
+            APIError: If request fails.
+        """
+        if not self._circuit_breaker.can_execute():
+            raise CircuitBreakerError(
+                f"Chat API circuit breaker is open - "
+                f"service unavailable after consecutive failures"
+            )
+
         headers = {
             'Content-Type': 'application/json',
             self.auth_header: self.auth_value
         }
-        return make_http_request(self.endpoint, data, headers, self.ssl_context)
+
+        try:
+            result = make_http_request(
+                self.endpoint, data, headers, self.ssl_context, timeout=self.timeout
+            )
+            self._circuit_breaker.record_success()
+            return result
+        except APIError:
+            self._circuit_breaker.record_failure()
+            raise
 
     def complete(self, prompt: str, system_prompt: Optional[str] = None) -> str:
         """Get a chat completion.
@@ -205,6 +474,7 @@ class ChatAPIClient:
 
         Raises:
             APIError: If the request fails.
+            CircuitBreakerError: If circuit breaker is open.
         """
         data = {'prompt': prompt}
         if system_prompt:
@@ -226,6 +496,7 @@ class ChatAPIClient:
 
         Raises:
             APIError: If the request fails.
+            CircuitBreakerError: If circuit breaker is open.
             ValueError: If the response is not valid JSON.
         """
         response = self.complete(prompt, system_prompt)
@@ -235,33 +506,68 @@ class ChatAPIClient:
         except json.JSONDecodeError as e:
             raise ValueError(f"Failed to parse response as JSON: {e}")
 
+    def is_available(self) -> bool:
+        """Check if the API is available (circuit breaker closed/half-open)."""
+        return self._circuit_breaker.can_execute()
+
+    def reset_circuit_breaker(self) -> None:
+        """Reset the circuit breaker to allow requests again."""
+        self._circuit_breaker.reset()
+
 
 # =============================================================================
 # OpenAI API Clients
 # =============================================================================
 
 class OpenAIVectorClient:
-    """Client for OpenAI embeddings API."""
+    """Client for OpenAI embeddings API.
+
+    Uses circuit breaker pattern to prevent cascading failures.
+    """
 
     ENDPOINT = 'https://api.openai.com/v1/embeddings'
 
-    def __init__(self, api_key: str, model: str = 'text-embedding-3-small'):
+    def __init__(self, api_key: str, model: str = 'text-embedding-3-small',
+                 timeout: float = DEFAULT_TIMEOUT,
+                 circuit_breaker: Optional[CircuitBreaker] = None):
         """Initialize the OpenAI vector client.
 
         Args:
             api_key: OpenAI API key.
             model: Embedding model to use.
+            timeout: Request timeout in seconds.
+            circuit_breaker: Optional circuit breaker (uses global if not provided).
         """
         self.api_key = api_key
         self.model = model
+        self.timeout = timeout
+        self._circuit_breaker = circuit_breaker or get_vector_circuit_breaker()
 
     def _make_request(self, data: Dict[str, Any]) -> Dict[str, Any]:
-        """Make an HTTP request to OpenAI API."""
+        """Make an HTTP request to OpenAI API.
+
+        Raises:
+            CircuitBreakerError: If circuit breaker is open.
+            APIError: If request fails.
+        """
+        if not self._circuit_breaker.can_execute():
+            raise CircuitBreakerError(
+                f"Vector API circuit breaker is open - "
+                f"service unavailable after consecutive failures"
+            )
+
         headers = {
             'Content-Type': 'application/json',
             'Authorization': f'Bearer {self.api_key}'
         }
-        return make_http_request(self.ENDPOINT, data, headers)
+
+        try:
+            result = make_http_request(self.ENDPOINT, data, headers, timeout=self.timeout)
+            self._circuit_breaker.record_success()
+            return result
+        except APIError:
+            self._circuit_breaker.record_failure()
+            raise
 
     def get_embedding(self, text: str) -> List[float]:
         """Get embedding for a single text.
@@ -274,6 +580,7 @@ class OpenAIVectorClient:
 
         Raises:
             APIError: If the request fails.
+            CircuitBreakerError: If circuit breaker is open.
         """
         data = {'input': text, 'model': self.model}
         response = self._make_request(data)
@@ -290,35 +597,71 @@ class OpenAIVectorClient:
 
         Raises:
             APIError: If the request fails.
+            CircuitBreakerError: If circuit breaker is open.
         """
         data = {'input': texts, 'model': self.model}
         response = self._make_request(data)
         sorted_data = sorted(response['data'], key=lambda x: x['index'])
         return [item['embedding'] for item in sorted_data]
 
+    def is_available(self) -> bool:
+        """Check if the API is available (circuit breaker closed/half-open)."""
+        return self._circuit_breaker.can_execute()
+
+    def reset_circuit_breaker(self) -> None:
+        """Reset the circuit breaker to allow requests again."""
+        self._circuit_breaker.reset()
+
 
 class OpenAIChatClient:
-    """Client for OpenAI chat completions API."""
+    """Client for OpenAI chat completions API.
+
+    Uses circuit breaker pattern to prevent cascading failures.
+    """
 
     ENDPOINT = 'https://api.openai.com/v1/chat/completions'
 
-    def __init__(self, api_key: str, model: str = 'gpt-4o-mini'):
+    def __init__(self, api_key: str, model: str = 'gpt-4o-mini',
+                 timeout: float = DEFAULT_TIMEOUT,
+                 circuit_breaker: Optional[CircuitBreaker] = None):
         """Initialize the OpenAI chat client.
 
         Args:
             api_key: OpenAI API key.
             model: Chat model to use.
+            timeout: Request timeout in seconds.
+            circuit_breaker: Optional circuit breaker (uses global if not provided).
         """
         self.api_key = api_key
         self.model = model
+        self.timeout = timeout
+        self._circuit_breaker = circuit_breaker or get_chat_circuit_breaker()
 
     def _make_request(self, data: Dict[str, Any]) -> Dict[str, Any]:
-        """Make an HTTP request to OpenAI API."""
+        """Make an HTTP request to OpenAI API.
+
+        Raises:
+            CircuitBreakerError: If circuit breaker is open.
+            APIError: If request fails.
+        """
+        if not self._circuit_breaker.can_execute():
+            raise CircuitBreakerError(
+                f"Chat API circuit breaker is open - "
+                f"service unavailable after consecutive failures"
+            )
+
         headers = {
             'Content-Type': 'application/json',
             'Authorization': f'Bearer {self.api_key}'
         }
-        return make_http_request(self.ENDPOINT, data, headers)
+
+        try:
+            result = make_http_request(self.ENDPOINT, data, headers, timeout=self.timeout)
+            self._circuit_breaker.record_success()
+            return result
+        except APIError:
+            self._circuit_breaker.record_failure()
+            raise
 
     def complete(self, prompt: str, system_prompt: Optional[str] = None) -> str:
         """Get a chat completion.
@@ -332,6 +675,7 @@ class OpenAIChatClient:
 
         Raises:
             APIError: If the request fails.
+            CircuitBreakerError: If circuit breaker is open.
         """
         messages = []
         if system_prompt:
@@ -355,6 +699,7 @@ class OpenAIChatClient:
 
         Raises:
             APIError: If the request fails.
+            CircuitBreakerError: If circuit breaker is open.
             ValueError: If the response is not valid JSON.
         """
         response = self.complete(prompt, system_prompt)
@@ -372,6 +717,14 @@ class OpenAIChatClient:
                 pass
 
         raise ValueError(f"Failed to parse response as JSON: {response[:200]}")
+
+    def is_available(self) -> bool:
+        """Check if the API is available (circuit breaker closed/half-open)."""
+        return self._circuit_breaker.can_execute()
+
+    def reset_circuit_breaker(self) -> None:
+        """Reset the circuit breaker to allow requests again."""
+        self._circuit_breaker.reset()
 
 
 # =============================================================================

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -284,5 +284,265 @@ class TestSSLConfiguration(unittest.TestCase):
         self.assertIsNotNone(client)
 
 
+class TestCircuitBreaker(unittest.TestCase):
+    """Test circuit breaker functionality."""
+
+    def test_circuit_breaker_starts_closed(self):
+        """Circuit breaker should start in closed state."""
+        from rag_system.api_client import CircuitBreaker
+
+        cb = CircuitBreaker(failure_threshold=3, reset_timeout=1.0)
+        self.assertEqual(cb.state, CircuitBreaker.CLOSED)
+        self.assertTrue(cb.can_execute())
+
+    def test_circuit_breaker_opens_after_threshold(self):
+        """Circuit breaker should open after failure threshold."""
+        from rag_system.api_client import CircuitBreaker
+
+        cb = CircuitBreaker(failure_threshold=3, reset_timeout=60.0)
+
+        # Record failures up to threshold
+        cb.record_failure()
+        self.assertTrue(cb.can_execute())
+        cb.record_failure()
+        self.assertTrue(cb.can_execute())
+        cb.record_failure()  # Threshold reached
+
+        self.assertEqual(cb.state, CircuitBreaker.OPEN)
+        self.assertFalse(cb.can_execute())
+
+    def test_circuit_breaker_closes_on_success(self):
+        """Circuit breaker should close on success after being open."""
+        from rag_system.api_client import CircuitBreaker
+
+        cb = CircuitBreaker(failure_threshold=2, reset_timeout=0.01)
+
+        # Open the circuit
+        cb.record_failure()
+        cb.record_failure()
+        self.assertFalse(cb.can_execute())
+
+        # Wait for reset timeout
+        import time
+        time.sleep(0.02)
+
+        # Should be half-open now
+        self.assertEqual(cb.state, CircuitBreaker.HALF_OPEN)
+        self.assertTrue(cb.can_execute())
+
+        # Success should close it
+        cb.record_success()
+        self.assertEqual(cb.state, CircuitBreaker.CLOSED)
+
+    def test_circuit_breaker_reset(self):
+        """reset() should return circuit breaker to closed state."""
+        from rag_system.api_client import CircuitBreaker
+
+        cb = CircuitBreaker(failure_threshold=1)
+        cb.record_failure()
+        self.assertFalse(cb.can_execute())
+
+        cb.reset()
+        self.assertEqual(cb.state, CircuitBreaker.CLOSED)
+        self.assertTrue(cb.can_execute())
+
+    def test_success_resets_failure_count(self):
+        """Success should reset failure count."""
+        from rag_system.api_client import CircuitBreaker
+
+        cb = CircuitBreaker(failure_threshold=3)
+
+        cb.record_failure()
+        cb.record_failure()
+        cb.record_success()  # Reset failure count
+        cb.record_failure()
+        cb.record_failure()  # Still under threshold
+
+        self.assertTrue(cb.can_execute())
+
+
+class TestCircuitBreakerIntegration(unittest.TestCase):
+    """Test circuit breaker integration with API clients."""
+
+    def test_vector_client_uses_circuit_breaker(self):
+        """VectorAPIClient should respect circuit breaker."""
+        from rag_system.api_client import (
+            VectorAPIClient, CircuitBreaker, CircuitBreakerError
+        )
+        import urllib.error
+
+        # Create a custom circuit breaker with low threshold
+        cb = CircuitBreaker(failure_threshold=2, reset_timeout=60.0)
+        client = VectorAPIClient(
+            endpoint='https://api.example.com/embed',
+            auth_header='Authorization',
+            auth_value='Bearer token',
+            circuit_breaker=cb
+        )
+
+        # Force circuit to open
+        with patch('urllib.request.urlopen',
+                   side_effect=urllib.error.HTTPError('url', 500, 'Error', {}, None)):
+            try:
+                client.get_embedding('test')
+            except Exception:
+                pass
+            try:
+                client.get_embedding('test')
+            except Exception:
+                pass
+
+        # Now circuit should be open
+        self.assertFalse(cb.can_execute())
+
+        # Attempting another request should raise CircuitBreakerError
+        with self.assertRaises(CircuitBreakerError):
+            client.get_embedding('test')
+
+    def test_chat_client_uses_circuit_breaker(self):
+        """ChatAPIClient should respect circuit breaker."""
+        from rag_system.api_client import (
+            ChatAPIClient, CircuitBreaker, CircuitBreakerError
+        )
+        import urllib.error
+
+        cb = CircuitBreaker(failure_threshold=2, reset_timeout=60.0)
+        client = ChatAPIClient(
+            endpoint='https://api.example.com/chat',
+            auth_header='Authorization',
+            auth_value='Bearer token',
+            circuit_breaker=cb
+        )
+
+        # Force circuit to open
+        with patch('urllib.request.urlopen',
+                   side_effect=urllib.error.HTTPError('url', 500, 'Error', {}, None)):
+            try:
+                client.complete('test')
+            except Exception:
+                pass
+            try:
+                client.complete('test')
+            except Exception:
+                pass
+
+        # Circuit should be open
+        self.assertFalse(cb.can_execute())
+
+        with self.assertRaises(CircuitBreakerError):
+            client.complete('test')
+
+    def test_client_is_available_method(self):
+        """Clients should have is_available() method."""
+        from rag_system.api_client import VectorAPIClient, CircuitBreaker
+
+        cb = CircuitBreaker(failure_threshold=1)
+        client = VectorAPIClient(
+            endpoint='https://api.example.com/embed',
+            auth_header='Authorization',
+            auth_value='Bearer token',
+            circuit_breaker=cb
+        )
+
+        self.assertTrue(client.is_available())
+        cb.record_failure()
+        self.assertFalse(client.is_available())
+
+    def test_client_reset_circuit_breaker_method(self):
+        """Clients should have reset_circuit_breaker() method."""
+        from rag_system.api_client import ChatAPIClient, CircuitBreaker
+
+        cb = CircuitBreaker(failure_threshold=1)
+        client = ChatAPIClient(
+            endpoint='https://api.example.com/chat',
+            auth_header='Authorization',
+            auth_value='Bearer token',
+            circuit_breaker=cb
+        )
+
+        cb.record_failure()
+        self.assertFalse(client.is_available())
+
+        client.reset_circuit_breaker()
+        self.assertTrue(client.is_available())
+
+
+class TestCustomExceptions(unittest.TestCase):
+    """Test custom exception classes."""
+
+    def test_api_error_has_attributes(self):
+        """APIError should store status_code and response."""
+        from rag_system.api_client import APIError
+
+        error = APIError("Test error", status_code=500, response='{"error": "Server Error"}')
+        self.assertEqual(str(error), "Test error")
+        self.assertEqual(error.status_code, 500)
+        self.assertEqual(error.response, '{"error": "Server Error"}')
+
+    def test_circuit_breaker_error_is_api_error(self):
+        """CircuitBreakerError should be subclass of APIError."""
+        from rag_system.api_client import APIError, CircuitBreakerError
+
+        self.assertTrue(issubclass(CircuitBreakerError, APIError))
+
+    def test_timeout_error_is_api_error(self):
+        """TimeoutError should be subclass of APIError."""
+        from rag_system.api_client import APIError, TimeoutError
+
+        self.assertTrue(issubclass(TimeoutError, APIError))
+
+
+class TestRetryBehavior(unittest.TestCase):
+    """Test HTTP request retry behavior."""
+
+    def test_retries_on_server_error(self):
+        """make_http_request should retry on 5xx errors."""
+        from rag_system.api_client import make_http_request, APIError
+        import urllib.error
+
+        call_count = [0]
+
+        def mock_urlopen(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] < 3:
+                raise urllib.error.HTTPError('url', 503, 'Service Unavailable', {}, None)
+            # Success on 3rd try
+            mock_response = MagicMock()
+            mock_response.read.return_value = b'{"result": "success"}'
+            mock_response.__enter__ = MagicMock(return_value=mock_response)
+            mock_response.__exit__ = MagicMock(return_value=False)
+            return mock_response
+
+        with patch('urllib.request.urlopen', side_effect=mock_urlopen):
+            with patch('time.sleep'):  # Skip actual delay
+                result = make_http_request(
+                    'https://api.example.com',
+                    {'data': 'test'},
+                    {'Content-Type': 'application/json'},
+                    max_retries=3
+                )
+
+        self.assertEqual(result['result'], 'success')
+        self.assertEqual(call_count[0], 3)
+
+    def test_raises_after_max_retries(self):
+        """make_http_request should raise after exhausting retries."""
+        from rag_system.api_client import make_http_request, APIError
+        import urllib.error
+
+        with patch('urllib.request.urlopen',
+                   side_effect=urllib.error.HTTPError('url', 503, 'Error', {}, None)):
+            with patch('time.sleep'):
+                with self.assertRaises(APIError) as ctx:
+                    make_http_request(
+                        'https://api.example.com',
+                        {'data': 'test'},
+                        {'Content-Type': 'application/json'},
+                        max_retries=2
+                    )
+
+                self.assertEqual(ctx.exception.status_code, 503)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

- Adds circuit breaker pattern to all API clients for fault tolerance
- Adds timeout parameter to HTTP requests (default 30 seconds)
- Adds CircuitBreakerError and TimeoutError exceptions
- Adds is_available() and reset_circuit_breaker() methods to all clients
- Adds retryable status codes: 429, 500, 502, 503, 504
- Adds JSON decode error handling in make_http_request
- Adds 14 new tests (total: 423 tests passing)

## Test plan

- [x] All 27 API client tests pass
- [x] Full test suite passes (423 tests)
- [x] Circuit breaker transitions: CLOSED → OPEN → HALF_OPEN → CLOSED
- [x] Retry behavior on 5xx errors verified
- [x] Exception hierarchy verified

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)