### PR TITLE
Issue #23: Query result caching with LRU and TTL

### DIFF
--- a/rag_system/config.py
+++ b/rag_system/config.py
@@ -162,6 +162,19 @@ LOG_LEVEL: str = os.environ.get('RAG_LOG_LEVEL', 'INFO')
 # Enable metrics collection
 METRICS_ENABLED: bool = os.environ.get('RAG_METRICS_ENABLED', 'true').lower() in ('true', '1', 'yes')
 
+# =============================================================================
+# Query Cache Configuration
+# =============================================================================
+
+# Enable query result caching
+QUERY_CACHE_ENABLED: bool = os.environ.get('RAG_QUERY_CACHE_ENABLED', 'true').lower() in ('true', '1', 'yes')
+
+# Maximum number of query results to cache
+QUERY_CACHE_SIZE: int = int(os.environ.get('RAG_QUERY_CACHE_SIZE', '100'))
+
+# Time-to-live for cached results in seconds (default: 1 hour)
+QUERY_CACHE_TTL: int = int(os.environ.get('RAG_QUERY_CACHE_TTL', '3600'))
+
 
 # =============================================================================
 # Configuration Validation
@@ -371,6 +384,17 @@ def validate_config(require_apis: bool = False) -> Tuple[bool, List[str]]:
             errors.append(
                 f"RAG_HTTP_CACHE_DIR parent directory does not exist: {cache_parent}"
             )
+
+    # Validate query cache settings
+    if QUERY_CACHE_SIZE <= 0:
+        errors.append(
+            f"RAG_QUERY_CACHE_SIZE must be positive, got {QUERY_CACHE_SIZE}"
+        )
+
+    if QUERY_CACHE_TTL < 0:
+        errors.append(
+            f"RAG_QUERY_CACHE_TTL must be non-negative, got {QUERY_CACHE_TTL}"
+        )
 
     return (len(errors) == 0, errors)
 

--- a/rag_system/main.py
+++ b/rag_system/main.py
@@ -35,10 +35,22 @@ from rag_system.query.expander import QueryExpander
 from rag_system.query.confidence import ConfidenceAnalyzer
 from rag_system.query.context_builder import ContextBuilder
 from rag_system.query.answer_generator import AnswerGenerator
-from rag_system.utils import get_logger, get_metrics_collector, Timer
+from rag_system.utils import get_logger, get_metrics_collector, Timer, LRUCache
 
 logger = get_logger(__name__)
 metrics_collector = get_metrics_collector()
+
+# Global query cache instance (initialized lazily by RAGSystem)
+_query_cache: Optional[LRUCache] = None
+
+
+def get_query_cache() -> Optional[LRUCache]:
+    """Get the global query cache instance.
+
+    Returns:
+        LRUCache instance or None if caching is disabled.
+    """
+    return _query_cache
 
 
 def parse_command(input_str: str) -> Tuple[str, List[str]]:
@@ -118,6 +130,17 @@ def create_parser() -> argparse.ArgumentParser:
     analytics_parser.add_argument(
         '--json', action='store_true',
         help='Output analytics as JSON'
+    )
+
+    # Cache command
+    cache_parser = subparsers.add_parser('cache', help='Manage query cache')
+    cache_parser.add_argument(
+        'action', choices=['stats', 'clear'],
+        help='Cache action: stats (show statistics) or clear (clear cache)'
+    )
+    cache_parser.add_argument(
+        '--json', action='store_true',
+        help='Output as JSON'
     )
 
     return parser
@@ -219,12 +242,26 @@ class RAGSystem:
         self.reranker = Reranker(self.db_path)
         self.diversifier = Diversifier(self.db_path)
 
-    def query(self, question: str, top_k: int = None) -> Dict[str, Any]:
+        # Initialize query result cache
+        global _query_cache
+        if config.QUERY_CACHE_ENABLED:
+            _query_cache = LRUCache(
+                max_size=config.QUERY_CACHE_SIZE,
+                ttl_seconds=config.QUERY_CACHE_TTL
+            )
+            logger.info(f"Query cache enabled: size={config.QUERY_CACHE_SIZE}, ttl={config.QUERY_CACHE_TTL}s")
+        else:
+            _query_cache = None
+            logger.info("Query cache disabled")
+
+    def query(self, question: str, top_k: int = None,
+              use_cache: bool = True) -> Dict[str, Any]:
         """Query the system.
 
         Args:
             question: Question to ask.
             top_k: Number of results.
+            use_cache: Whether to use the query result cache.
 
         Returns:
             Result dict with answer, chunks, confidence, and timing metrics.
@@ -243,6 +280,18 @@ class RAGSystem:
 
         # Generate query hash for caching
         query_hash = hashlib.md5(question.lower().strip().encode()).hexdigest()
+
+        # Check query result cache first
+        cache_key = f"{query_hash}:{top_k}"
+        if use_cache and _query_cache is not None:
+            cached_result = _query_cache.get(cache_key)
+            if cached_result is not None:
+                # Add cache hit info to result
+                cached_result = cached_result.copy()
+                cached_result['cache_hit'] = True
+                cached_result['timing'] = {'total_time': time.time() - query_start_time}
+                logger.debug(f"Cache hit for query: {sanitize_for_logging(question, 50)}")
+                return cached_result
 
         # Check cache for query processing results
         conn = get_connection(self.db_path)
@@ -379,15 +428,23 @@ class RAGSystem:
         for name, value in timing_metrics.items():
             metrics_collector.record(name, value)
 
-        return {
+        result = {
             'query': question,
             'query_type': query_type,
             'answer': answer,
             'chunks': chunks,
             'confidence': metrics['overall'],
             'metrics': metrics,
-            'timing': timing_metrics
+            'timing': timing_metrics,
+            'cache_hit': False
         }
+
+        # Store result in cache
+        if use_cache and _query_cache is not None:
+            _query_cache.put(cache_key, result)
+            logger.debug(f"Cached result for query: {sanitize_for_logging(question, 50)}")
+
+        return result
 
     def ingest(self, start_url: str, max_pages: int = None,
                 ignore_robots: bool = False) -> Dict[str, Any]:
@@ -456,6 +513,36 @@ class RAGSystem:
         finally:
             conn.close()
 
+    def get_cache_stats(self) -> Optional[Dict[str, Any]]:
+        """Get query cache statistics.
+
+        Returns:
+            Dict with cache stats, or None if caching is disabled.
+        """
+        if _query_cache is None:
+            return None
+        return _query_cache.get_stats()
+
+    def clear_cache(self) -> bool:
+        """Clear the query result cache.
+
+        Returns:
+            True if cache was cleared, False if caching is disabled.
+        """
+        if _query_cache is None:
+            return False
+        _query_cache.clear()
+        logger.info("Query result cache cleared")
+        return True
+
+    def invalidate_cache(self) -> bool:
+        """Invalidate cache entries (call when database changes).
+
+        Returns:
+            True if cache was invalidated, False if caching is disabled.
+        """
+        return self.clear_cache()
+
 
 def run_interactive(rag: RAGSystem) -> None:
     """Run interactive mode.
@@ -486,10 +573,25 @@ def run_interactive(rag: RAGSystem) -> None:
             print("Commands:")
             print("  query <question>  - Ask a question")
             print("  stats             - Show statistics")
+            print("  cache             - Show cache statistics")
+            print("  cache clear       - Clear the cache")
             print("  quit/exit         - Exit")
         elif cmd == 'stats':
             stats = rag.get_stats()
             print(format_stats(stats))
+        elif cmd == 'cache':
+            if args and args[0] == 'clear':
+                if rag.clear_cache():
+                    print("Cache cleared")
+                else:
+                    print("Caching is disabled")
+            else:
+                cache_stats = rag.get_cache_stats()
+                if cache_stats is None:
+                    print("Caching is disabled")
+                else:
+                    print(f"Cache: {cache_stats['size']}/{cache_stats['max_size']} entries, "
+                          f"hit rate: {cache_stats['hit_rate']:.1%}")
         elif cmd == 'query' and args:
             result = rag.query(args[0])
             print(format_query_result(result))
@@ -596,6 +698,30 @@ def main() -> None:
                             print(f"  Generation: {timing['avg_generation_ms']:.1f}ms")
             finally:
                 conn.close()
+
+        elif args.command == 'cache':
+            import json as json_module
+            cache_stats = rag.get_cache_stats()
+
+            if args.action == 'stats':
+                if cache_stats is None:
+                    print("Query caching is disabled")
+                elif args.json:
+                    print(json_module.dumps(cache_stats, indent=2))
+                else:
+                    print("Query Cache Statistics")
+                    print("=" * 40)
+                    print(f"Size: {cache_stats['size']} / {cache_stats['max_size']}")
+                    print(f"TTL: {cache_stats['ttl_seconds']} seconds")
+                    print(f"Hits: {cache_stats['hits']}")
+                    print(f"Misses: {cache_stats['misses']}")
+                    print(f"Evictions: {cache_stats['evictions']}")
+                    print(f"Hit Rate: {cache_stats['hit_rate']:.1%}")
+            elif args.action == 'clear':
+                if rag.clear_cache():
+                    print("Cache cleared successfully")
+                else:
+                    print("Query caching is disabled")
 
     except KeyboardInterrupt:
         print("\nShutdown requested")

--- a/rag_system/utils.py
+++ b/rag_system/utils.py
@@ -489,3 +489,211 @@ def retry(max_attempts: int = 3, delay: float = 1.0,
             raise last_exception
         return wrapper
     return decorator
+
+
+# =============================================================================
+# LRU Cache with TTL
+# =============================================================================
+
+class LRUCache:
+    """Thread-safe LRU cache with time-to-live (TTL) support.
+
+    Entries are evicted based on access time (LRU) and age (TTL).
+    Uses doubly linked list for O(1) LRU operations.
+    """
+
+    def __init__(self, max_size: int, ttl_seconds: int):
+        """Initialize the LRU cache.
+
+        Args:
+            max_size: Maximum number of entries to store.
+            ttl_seconds: Time-to-live in seconds for cache entries.
+        """
+        self.max_size = max_size
+        self.ttl_seconds = ttl_seconds
+        self._lock = threading.Lock()
+
+        # Storage: key -> (value, timestamp, prev_key, next_key)
+        self._cache: Dict[str, tuple] = {}
+
+        # Doubly linked list head/tail for LRU ordering
+        self._head: Optional[str] = None  # Most recently used
+        self._tail: Optional[str] = None  # Least recently used
+
+        # Statistics
+        self._hits = 0
+        self._misses = 0
+        self._evictions = 0
+
+    def _is_expired(self, timestamp: float) -> bool:
+        """Check if an entry has expired based on TTL."""
+        if self.ttl_seconds <= 0:
+            return False
+        return time.time() - timestamp > self.ttl_seconds
+
+    def _remove_from_list(self, key: str) -> None:
+        """Remove a key from the linked list (internal, assumes lock held)."""
+        if key not in self._cache:
+            return
+
+        _, _, prev_key, next_key = self._cache[key]
+
+        if prev_key is not None:
+            value, ts, pp, _ = self._cache[prev_key]
+            self._cache[prev_key] = (value, ts, pp, next_key)
+        else:
+            self._head = next_key
+
+        if next_key is not None:
+            value, ts, _, nn = self._cache[next_key]
+            self._cache[next_key] = (value, ts, prev_key, nn)
+        else:
+            self._tail = prev_key
+
+    def _add_to_head(self, key: str) -> None:
+        """Add a key to the head of the list (internal, assumes lock held)."""
+        if key not in self._cache:
+            return
+
+        value, ts, _, _ = self._cache[key]
+        old_head = self._head
+
+        self._cache[key] = (value, ts, None, old_head)
+        self._head = key
+
+        if old_head is not None:
+            value, ts, _, next_key = self._cache[old_head]
+            self._cache[old_head] = (value, ts, key, next_key)
+
+        if self._tail is None:
+            self._tail = key
+
+    def _evict_lru(self) -> None:
+        """Evict the least recently used entry (internal, assumes lock held)."""
+        if self._tail is None:
+            return
+
+        key_to_remove = self._tail
+        self._remove_from_list(key_to_remove)
+        del self._cache[key_to_remove]
+        self._evictions += 1
+
+    def get(self, key: str) -> Optional[Any]:
+        """Get a value from the cache.
+
+        Args:
+            key: Cache key.
+
+        Returns:
+            Cached value or None if not found/expired.
+        """
+        with self._lock:
+            if key not in self._cache:
+                self._misses += 1
+                return None
+
+            value, timestamp, _, _ = self._cache[key]
+
+            # Check if expired
+            if self._is_expired(timestamp):
+                self._remove_from_list(key)
+                del self._cache[key]
+                self._misses += 1
+                return None
+
+            # Move to head (most recently used)
+            self._remove_from_list(key)
+            self._cache[key] = (value, timestamp, None, None)
+            self._add_to_head(key)
+
+            self._hits += 1
+            return value
+
+    def put(self, key: str, value: Any) -> None:
+        """Put a value in the cache.
+
+        Args:
+            key: Cache key.
+            value: Value to cache.
+        """
+        with self._lock:
+            # Update existing entry
+            if key in self._cache:
+                self._remove_from_list(key)
+
+            # Evict if at capacity
+            while len(self._cache) >= self.max_size:
+                self._evict_lru()
+
+            # Add new entry
+            self._cache[key] = (value, time.time(), None, None)
+            self._add_to_head(key)
+
+    def delete(self, key: str) -> bool:
+        """Delete an entry from the cache.
+
+        Args:
+            key: Cache key.
+
+        Returns:
+            True if the entry was found and deleted.
+        """
+        with self._lock:
+            if key not in self._cache:
+                return False
+
+            self._remove_from_list(key)
+            del self._cache[key]
+            return True
+
+    def clear(self) -> None:
+        """Clear all entries from the cache."""
+        with self._lock:
+            self._cache.clear()
+            self._head = None
+            self._tail = None
+            # Don't reset statistics on clear
+
+    def get_stats(self) -> Dict[str, int]:
+        """Get cache statistics.
+
+        Returns:
+            Dict with hits, misses, evictions, and size.
+        """
+        with self._lock:
+            total = self._hits + self._misses
+            hit_rate = self._hits / total if total > 0 else 0.0
+            return {
+                'hits': self._hits,
+                'misses': self._misses,
+                'evictions': self._evictions,
+                'size': len(self._cache),
+                'max_size': self.max_size,
+                'ttl_seconds': self.ttl_seconds,
+                'hit_rate': round(hit_rate, 4)
+            }
+
+    def reset_stats(self) -> None:
+        """Reset cache statistics."""
+        with self._lock:
+            self._hits = 0
+            self._misses = 0
+            self._evictions = 0
+
+    def cleanup_expired(self) -> int:
+        """Remove all expired entries from the cache.
+
+        Returns:
+            Number of entries removed.
+        """
+        with self._lock:
+            keys_to_remove = []
+            for key, (_, timestamp, _, _) in self._cache.items():
+                if self._is_expired(timestamp):
+                    keys_to_remove.append(key)
+
+            for key in keys_to_remove:
+                self._remove_from_list(key)
+                del self._cache[key]
+
+            return len(keys_to_remove)

--- a/tests/test_query_cache.py
+++ b/tests/test_query_cache.py
@@ -1,0 +1,296 @@
+"""Tests for query result caching."""
+
+import time
+import unittest
+
+from rag_system.utils import LRUCache
+
+
+class TestLRUCacheBasic(unittest.TestCase):
+    """Test basic LRU cache operations."""
+
+    def test_put_and_get(self):
+        """put and get should store and retrieve values."""
+        cache = LRUCache(max_size=10, ttl_seconds=60)
+        cache.put('key1', 'value1')
+
+        result = cache.get('key1')
+
+        self.assertEqual(result, 'value1')
+
+    def test_get_nonexistent_returns_none(self):
+        """get should return None for nonexistent keys."""
+        cache = LRUCache(max_size=10, ttl_seconds=60)
+
+        result = cache.get('nonexistent')
+
+        self.assertIsNone(result)
+
+    def test_delete_removes_entry(self):
+        """delete should remove an entry from the cache."""
+        cache = LRUCache(max_size=10, ttl_seconds=60)
+        cache.put('key1', 'value1')
+
+        result = cache.delete('key1')
+
+        self.assertTrue(result)
+        self.assertIsNone(cache.get('key1'))
+
+    def test_delete_nonexistent_returns_false(self):
+        """delete should return False for nonexistent keys."""
+        cache = LRUCache(max_size=10, ttl_seconds=60)
+
+        result = cache.delete('nonexistent')
+
+        self.assertFalse(result)
+
+    def test_clear_removes_all_entries(self):
+        """clear should remove all entries from the cache."""
+        cache = LRUCache(max_size=10, ttl_seconds=60)
+        cache.put('key1', 'value1')
+        cache.put('key2', 'value2')
+
+        cache.clear()
+
+        self.assertIsNone(cache.get('key1'))
+        self.assertIsNone(cache.get('key2'))
+
+    def test_update_existing_key(self):
+        """put should update existing key with new value."""
+        cache = LRUCache(max_size=10, ttl_seconds=60)
+        cache.put('key1', 'value1')
+        cache.put('key1', 'value2')
+
+        result = cache.get('key1')
+
+        self.assertEqual(result, 'value2')
+
+
+class TestLRUCacheEviction(unittest.TestCase):
+    """Test LRU cache eviction behavior."""
+
+    def test_evicts_lru_when_full(self):
+        """Cache should evict least recently used entry when full."""
+        cache = LRUCache(max_size=3, ttl_seconds=60)
+        cache.put('key1', 'value1')
+        cache.put('key2', 'value2')
+        cache.put('key3', 'value3')
+
+        # Adding a fourth item should evict key1 (least recently used)
+        cache.put('key4', 'value4')
+
+        self.assertIsNone(cache.get('key1'))
+        self.assertIsNotNone(cache.get('key2'))
+        self.assertIsNotNone(cache.get('key3'))
+        self.assertIsNotNone(cache.get('key4'))
+
+    def test_access_updates_lru_order(self):
+        """Accessing an entry should update its LRU position."""
+        cache = LRUCache(max_size=3, ttl_seconds=60)
+        cache.put('key1', 'value1')
+        cache.put('key2', 'value2')
+        cache.put('key3', 'value3')
+
+        # Access key1 to make it recently used
+        cache.get('key1')
+
+        # Adding key4 should now evict key2 (oldest unaccessed)
+        cache.put('key4', 'value4')
+
+        self.assertIsNotNone(cache.get('key1'))
+        self.assertIsNone(cache.get('key2'))
+        self.assertIsNotNone(cache.get('key3'))
+        self.assertIsNotNone(cache.get('key4'))
+
+    def test_eviction_count_in_stats(self):
+        """Evictions should be counted in statistics."""
+        cache = LRUCache(max_size=2, ttl_seconds=60)
+        cache.put('key1', 'value1')
+        cache.put('key2', 'value2')
+        cache.put('key3', 'value3')  # Evicts key1
+
+        stats = cache.get_stats()
+
+        self.assertEqual(stats['evictions'], 1)
+
+
+class TestLRUCacheTTL(unittest.TestCase):
+    """Test LRU cache TTL (time-to-live) behavior."""
+
+    def test_expired_entry_returns_none(self):
+        """Expired entries should return None."""
+        cache = LRUCache(max_size=10, ttl_seconds=1)
+        cache.put('key1', 'value1')
+
+        # Wait for expiration
+        time.sleep(1.1)
+
+        result = cache.get('key1')
+
+        self.assertIsNone(result)
+
+    def test_unexpired_entry_returns_value(self):
+        """Unexpired entries should return their value."""
+        cache = LRUCache(max_size=10, ttl_seconds=60)
+        cache.put('key1', 'value1')
+
+        result = cache.get('key1')
+
+        self.assertEqual(result, 'value1')
+
+    def test_cleanup_expired_removes_old_entries(self):
+        """cleanup_expired should remove expired entries."""
+        cache = LRUCache(max_size=10, ttl_seconds=1)
+        cache.put('key1', 'value1')
+        cache.put('key2', 'value2')
+
+        # Wait for expiration
+        time.sleep(1.1)
+
+        removed = cache.cleanup_expired()
+
+        self.assertEqual(removed, 2)
+
+    def test_zero_ttl_disables_expiration(self):
+        """TTL of 0 should disable expiration."""
+        cache = LRUCache(max_size=10, ttl_seconds=0)
+        cache.put('key1', 'value1')
+
+        # Even with a pause, entry should not expire
+        time.sleep(0.1)
+
+        result = cache.get('key1')
+
+        self.assertEqual(result, 'value1')
+
+
+class TestLRUCacheStats(unittest.TestCase):
+    """Test LRU cache statistics."""
+
+    def test_hit_count(self):
+        """Stats should track cache hits."""
+        cache = LRUCache(max_size=10, ttl_seconds=60)
+        cache.put('key1', 'value1')
+        cache.get('key1')
+        cache.get('key1')
+
+        stats = cache.get_stats()
+
+        self.assertEqual(stats['hits'], 2)
+
+    def test_miss_count(self):
+        """Stats should track cache misses."""
+        cache = LRUCache(max_size=10, ttl_seconds=60)
+        cache.get('nonexistent')
+        cache.get('also_nonexistent')
+
+        stats = cache.get_stats()
+
+        self.assertEqual(stats['misses'], 2)
+
+    def test_hit_rate_calculation(self):
+        """Stats should calculate hit rate correctly."""
+        cache = LRUCache(max_size=10, ttl_seconds=60)
+        cache.put('key1', 'value1')
+        cache.get('key1')  # Hit
+        cache.get('key1')  # Hit
+        cache.get('nonexistent')  # Miss
+
+        stats = cache.get_stats()
+
+        # 2 hits / 3 total = 0.6667
+        self.assertAlmostEqual(stats['hit_rate'], 0.6667, places=3)
+
+    def test_size_tracking(self):
+        """Stats should track current size."""
+        cache = LRUCache(max_size=10, ttl_seconds=60)
+        cache.put('key1', 'value1')
+        cache.put('key2', 'value2')
+
+        stats = cache.get_stats()
+
+        self.assertEqual(stats['size'], 2)
+        self.assertEqual(stats['max_size'], 10)
+
+    def test_reset_stats(self):
+        """reset_stats should clear hit/miss/eviction counts."""
+        cache = LRUCache(max_size=10, ttl_seconds=60)
+        cache.put('key1', 'value1')
+        cache.get('key1')
+        cache.get('nonexistent')
+
+        cache.reset_stats()
+        stats = cache.get_stats()
+
+        self.assertEqual(stats['hits'], 0)
+        self.assertEqual(stats['misses'], 0)
+        self.assertEqual(stats['evictions'], 0)
+        # Size should still be tracked
+        self.assertEqual(stats['size'], 1)
+
+
+class TestLRUCacheThreadSafety(unittest.TestCase):
+    """Test LRU cache thread safety."""
+
+    def test_concurrent_put_and_get(self):
+        """Cache should handle concurrent access safely."""
+        import threading
+
+        cache = LRUCache(max_size=100, ttl_seconds=60)
+        errors = []
+
+        def put_values(start, end):
+            try:
+                for i in range(start, end):
+                    cache.put(f'key{i}', f'value{i}')
+            except Exception as e:
+                errors.append(e)
+
+        def get_values(start, end):
+            try:
+                for i in range(start, end):
+                    cache.get(f'key{i}')
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=put_values, args=(0, 50)),
+            threading.Thread(target=put_values, args=(50, 100)),
+            threading.Thread(target=get_values, args=(0, 100)),
+            threading.Thread(target=get_values, args=(0, 100)),
+        ]
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(len(errors), 0)
+
+
+class TestLRUCacheComplexValues(unittest.TestCase):
+    """Test LRU cache with complex value types."""
+
+    def test_dict_values(self):
+        """Cache should store and retrieve dict values."""
+        cache = LRUCache(max_size=10, ttl_seconds=60)
+        value = {'answer': 'test', 'chunks': [1, 2, 3], 'confidence': 0.9}
+        cache.put('key1', value)
+
+        result = cache.get('key1')
+
+        self.assertEqual(result, value)
+
+    def test_list_values(self):
+        """Cache should store and retrieve list values."""
+        cache = LRUCache(max_size=10, ttl_seconds=60)
+        value = [1, 2, 3, 'test', {'nested': True}]
+        cache.put('key1', value)
+
+        result = cache.get('key1')
+
+        self.assertEqual(result, value)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add thread-safe LRU cache with TTL support in `utils.py`
- Configure via `RAG_QUERY_CACHE_ENABLED`, `RAG_QUERY_CACHE_SIZE`, `RAG_QUERY_CACHE_TTL`
- Add cache management methods to `RAGSystem` (get_cache_stats, clear_cache)
- Add `cache stats/clear` CLI command
- Add interactive mode cache commands
- Comprehensive test suite with 21 tests

## Test plan
- [x] Test basic cache operations (put, get, delete, clear)
- [x] Test LRU eviction behavior
- [x] Test TTL expiration
- [x] Test statistics tracking
- [x] Test thread safety
- [x] Run full test suite (589 tests pass)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)