### PR TITLE
Issue #50: Crawler resume capability

### DIFF
--- a/rag_system/database.py
+++ b/rag_system/database.py
@@ -239,6 +239,33 @@ CREATE TABLE IF NOT EXISTS query_log (
 );
 
 -- ============================================
+-- CRAWL SESSION MANAGEMENT
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS crawl_sessions (
+    id INTEGER PRIMARY KEY,
+    start_url TEXT NOT NULL,
+    allowed_domains TEXT NOT NULL,  -- JSON array
+    status TEXT DEFAULT 'active',   -- active, completed, interrupted
+    pages_crawled INTEGER DEFAULT 0,
+    pages_indexed INTEGER DEFAULT 0,
+    pages_skipped INTEGER DEFAULT 0,
+    errors INTEGER DEFAULT 0,
+    started_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    completed_at TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS crawl_queue (
+    id INTEGER PRIMARY KEY,
+    session_id INTEGER NOT NULL,
+    url TEXT NOT NULL,
+    depth INTEGER DEFAULT 0,
+    added_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (session_id) REFERENCES crawl_sessions(id),
+    UNIQUE(session_id, url)
+);
+
+-- ============================================
 -- INDEXES
 -- ============================================
 
@@ -249,6 +276,8 @@ CREATE INDEX IF NOT EXISTS idx_entities_type ON entities(type);
 CREATE INDEX IF NOT EXISTS idx_entities_normalized ON entities(normalized_name);
 CREATE INDEX IF NOT EXISTS idx_doc_terms_term ON doc_terms(term);
 CREATE INDEX IF NOT EXISTS idx_doc_terms_chunk ON doc_terms(chunk_id);
+CREATE INDEX IF NOT EXISTS idx_crawl_queue_session ON crawl_queue(session_id);
+CREATE INDEX IF NOT EXISTS idx_crawl_sessions_url ON crawl_sessions(start_url);
 """
 
 
@@ -1430,3 +1459,379 @@ def export_query_logs_csv(conn: sqlite3.Connection, filepath: str,
         return len(rows)
     except (sqlite3.Error, IOError) as e:
         raise QueryError(f"Failed to export query logs: {e}") from e
+
+
+# =============================================================================
+# Crawl Session Operations
+# =============================================================================
+
+def create_crawl_session(conn: sqlite3.Connection, start_url: str,
+                         allowed_domains: List[str], max_pages: int,
+                         auto_commit: bool = True) -> int:
+    """Create a new crawl session.
+
+    Args:
+        conn: Database connection.
+        start_url: Starting URL for the crawl.
+        allowed_domains: List of allowed domains to crawl.
+        max_pages: Maximum number of pages to crawl.
+        auto_commit: If True, commit after insert.
+
+    Returns:
+        ID of the created session.
+
+    Raises:
+        QueryError: If insert fails.
+    """
+    try:
+        cursor = conn.execute(
+            """INSERT INTO crawl_sessions
+               (start_url, allowed_domains, status, pages_crawled, pages_indexed, pages_skipped, errors)
+               VALUES (?, ?, 'active', 0, 0, 0, 0)""",
+            (start_url, json.dumps(allowed_domains))
+        )
+        if auto_commit:
+            conn.commit()
+        return cursor.lastrowid
+    except sqlite3.Error as e:
+        if auto_commit:
+            conn.rollback()
+        raise QueryError(f"Failed to create crawl session: {e}") from e
+
+
+def get_crawl_session(conn: sqlite3.Connection, session_id: int) -> Optional[Dict[str, Any]]:
+    """Get a crawl session by ID.
+
+    Args:
+        conn: Database connection.
+        session_id: ID of the session to retrieve.
+
+    Returns:
+        Session dict or None if not found.
+    """
+    cursor = conn.execute(
+        "SELECT * FROM crawl_sessions WHERE id = ?",
+        (session_id,)
+    )
+    row = cursor.fetchone()
+    if row:
+        result = dict(row)
+        result['allowed_domains'] = json.loads(result['allowed_domains'])
+        return result
+    return None
+
+
+def get_active_session_for_url(conn: sqlite3.Connection, start_url: str) -> Optional[Dict[str, Any]]:
+    """Find an active or interrupted session for a given URL.
+
+    Used to determine if a crawl can be resumed.
+
+    Args:
+        conn: Database connection.
+        start_url: Starting URL to match.
+
+    Returns:
+        Session dict or None if no resumable session exists.
+    """
+    cursor = conn.execute(
+        """SELECT * FROM crawl_sessions
+           WHERE start_url = ? AND status IN ('active', 'interrupted')
+           ORDER BY started_at DESC LIMIT 1""",
+        (start_url,)
+    )
+    row = cursor.fetchone()
+    if row:
+        result = dict(row)
+        result['allowed_domains'] = json.loads(result['allowed_domains'])
+        return result
+    return None
+
+
+def update_session_status(conn: sqlite3.Connection, session_id: int,
+                          status: str, auto_commit: bool = True) -> None:
+    """Update crawl session status.
+
+    Args:
+        conn: Database connection.
+        session_id: ID of the session to update.
+        status: New status ('active', 'completed', 'interrupted').
+        auto_commit: If True, commit after update.
+
+    Raises:
+        QueryError: If update fails.
+    """
+    try:
+        completed_at = "CURRENT_TIMESTAMP" if status == 'completed' else "NULL"
+        conn.execute(
+            f"""UPDATE crawl_sessions
+               SET status = ?, completed_at = {completed_at}
+               WHERE id = ?""",
+            (status, session_id)
+        )
+        if auto_commit:
+            conn.commit()
+    except sqlite3.Error as e:
+        if auto_commit:
+            conn.rollback()
+        raise QueryError(f"Failed to update session status: {e}") from e
+
+
+def update_session_stats(conn: sqlite3.Connection, session_id: int,
+                         pages_crawled: int = None, pages_indexed: int = None,
+                         pages_skipped: int = None, errors: int = None,
+                         auto_commit: bool = True) -> None:
+    """Update crawl session statistics.
+
+    Args:
+        conn: Database connection.
+        session_id: ID of the session to update.
+        pages_crawled: Number of pages successfully fetched.
+        pages_indexed: Number of pages indexed.
+        pages_skipped: Number of pages skipped.
+        errors: Number of errors encountered.
+        auto_commit: If True, commit after update.
+
+    Raises:
+        QueryError: If update fails.
+    """
+    try:
+        updates = []
+        params = []
+        if pages_crawled is not None:
+            updates.append("pages_crawled = ?")
+            params.append(pages_crawled)
+        if pages_indexed is not None:
+            updates.append("pages_indexed = ?")
+            params.append(pages_indexed)
+        if pages_skipped is not None:
+            updates.append("pages_skipped = ?")
+            params.append(pages_skipped)
+        if errors is not None:
+            updates.append("errors = ?")
+            params.append(errors)
+
+        if updates:
+            params.append(session_id)
+            conn.execute(
+                f"UPDATE crawl_sessions SET {', '.join(updates)} WHERE id = ?",
+                params
+            )
+            if auto_commit:
+                conn.commit()
+    except sqlite3.Error as e:
+        if auto_commit:
+            conn.rollback()
+        raise QueryError(f"Failed to update session stats: {e}") from e
+
+
+def list_crawl_sessions(conn: sqlite3.Connection,
+                        limit: int = 50) -> List[Dict[str, Any]]:
+    """List all crawl sessions.
+
+    Args:
+        conn: Database connection.
+        limit: Maximum number of sessions to return.
+
+    Returns:
+        List of session dicts ordered by started_at descending, then id descending.
+    """
+    cursor = conn.execute(
+        "SELECT * FROM crawl_sessions ORDER BY started_at DESC, id DESC LIMIT ?",
+        (limit,)
+    )
+    sessions = []
+    for row in cursor.fetchall():
+        session = dict(row)
+        session['allowed_domains'] = json.loads(session['allowed_domains'])
+        sessions.append(session)
+    return sessions
+
+
+def acquire_session_lock(conn: sqlite3.Connection, session_id: int,
+                         auto_commit: bool = True) -> bool:
+    """Attempt to acquire a lock on a crawl session.
+
+    Only succeeds if the session is in 'interrupted' status.
+
+    Args:
+        conn: Database connection.
+        session_id: ID of the session to lock.
+        auto_commit: If True, commit after update.
+
+    Returns:
+        True if lock acquired, False if session is already active.
+    """
+    try:
+        cursor = conn.execute(
+            """UPDATE crawl_sessions
+               SET status = 'active'
+               WHERE id = ? AND status = 'interrupted'""",
+            (session_id,)
+        )
+        if auto_commit:
+            conn.commit()
+        return cursor.rowcount > 0
+    except sqlite3.Error as e:
+        if auto_commit:
+            conn.rollback()
+        raise QueryError(f"Failed to acquire session lock: {e}") from e
+
+
+def release_session_lock(conn: sqlite3.Connection, session_id: int,
+                         auto_commit: bool = True) -> None:
+    """Release a lock on a crawl session by marking it interrupted.
+
+    Args:
+        conn: Database connection.
+        session_id: ID of the session to release.
+        auto_commit: If True, commit after update.
+    """
+    update_session_status(conn, session_id, 'interrupted', auto_commit)
+
+
+# =============================================================================
+# Crawl Queue Operations
+# =============================================================================
+
+def add_urls_to_crawl_queue(conn: sqlite3.Connection, session_id: int,
+                            urls: List[str], depth: int = 0,
+                            auto_commit: bool = True) -> int:
+    """Add URLs to the crawl queue.
+
+    Duplicates are silently ignored (uses INSERT OR IGNORE).
+
+    Args:
+        conn: Database connection.
+        session_id: ID of the crawl session.
+        urls: List of URLs to add.
+        depth: Crawl depth for these URLs.
+        auto_commit: If True, commit after insert.
+
+    Returns:
+        Number of URLs actually added (excludes duplicates).
+
+    Raises:
+        QueryError: If insert fails.
+    """
+    if not urls:
+        return 0
+
+    try:
+        added = 0
+        for url in urls:
+            cursor = conn.execute(
+                """INSERT OR IGNORE INTO crawl_queue (session_id, url, depth)
+                   VALUES (?, ?, ?)""",
+                (session_id, url, depth)
+            )
+            added += cursor.rowcount
+        if auto_commit:
+            conn.commit()
+        return added
+    except sqlite3.Error as e:
+        if auto_commit:
+            conn.rollback()
+        raise QueryError(f"Failed to add URLs to crawl queue: {e}") from e
+
+
+def pop_from_crawl_queue(conn: sqlite3.Connection, session_id: int,
+                         auto_commit: bool = True) -> Optional[tuple]:
+    """Pop the oldest URL from the crawl queue (FIFO).
+
+    Args:
+        conn: Database connection.
+        session_id: ID of the crawl session.
+        auto_commit: If True, commit after delete.
+
+    Returns:
+        Tuple of (url, depth) or None if queue is empty.
+
+    Raises:
+        QueryError: If operation fails.
+    """
+    try:
+        cursor = conn.execute(
+            """SELECT id, url, depth FROM crawl_queue
+               WHERE session_id = ?
+               ORDER BY added_at ASC, id ASC
+               LIMIT 1""",
+            (session_id,)
+        )
+        row = cursor.fetchone()
+        if not row:
+            return None
+
+        queue_id, url, depth = row['id'], row['url'], row['depth']
+        conn.execute("DELETE FROM crawl_queue WHERE id = ?", (queue_id,))
+        if auto_commit:
+            conn.commit()
+        return (url, depth)
+    except sqlite3.Error as e:
+        if auto_commit:
+            conn.rollback()
+        raise QueryError(f"Failed to pop from crawl queue: {e}") from e
+
+
+def get_crawl_queue_size(conn: sqlite3.Connection, session_id: int) -> int:
+    """Get the number of URLs in the crawl queue.
+
+    Args:
+        conn: Database connection.
+        session_id: ID of the crawl session.
+
+    Returns:
+        Number of URLs in the queue.
+    """
+    cursor = conn.execute(
+        "SELECT COUNT(*) FROM crawl_queue WHERE session_id = ?",
+        (session_id,)
+    )
+    return cursor.fetchone()[0]
+
+
+def get_crawl_queue_urls(conn: sqlite3.Connection, session_id: int) -> List[str]:
+    """Get all URLs in the crawl queue.
+
+    Args:
+        conn: Database connection.
+        session_id: ID of the crawl session.
+
+    Returns:
+        List of URLs in FIFO order.
+    """
+    cursor = conn.execute(
+        """SELECT url FROM crawl_queue
+           WHERE session_id = ?
+           ORDER BY added_at ASC, id ASC""",
+        (session_id,)
+    )
+    return [row['url'] for row in cursor.fetchall()]
+
+
+def clear_crawl_queue(conn: sqlite3.Connection, session_id: int,
+                      auto_commit: bool = True) -> int:
+    """Remove all URLs from the crawl queue.
+
+    Args:
+        conn: Database connection.
+        session_id: ID of the crawl session.
+        auto_commit: If True, commit after delete.
+
+    Returns:
+        Number of URLs removed.
+
+    Raises:
+        QueryError: If delete fails.
+    """
+    try:
+        cursor = conn.execute(
+            "DELETE FROM crawl_queue WHERE session_id = ?",
+            (session_id,)
+        )
+        if auto_commit:
+            conn.commit()
+        return cursor.rowcount
+    except sqlite3.Error as e:
+        if auto_commit:
+            conn.rollback()
+        raise QueryError(f"Failed to clear crawl queue: {e}") from e

--- a/rag_system/ingestion/indexer.py
+++ b/rag_system/ingestion/indexer.py
@@ -13,7 +13,10 @@ from rag_system.api_client import APIError
 from rag_system.database import (
     get_connection, insert_page, get_page_by_url,
     insert_chunk, update_chunk_embedding,
-    delete_chunks_by_page, delete_doc_terms_by_page, update_page_content
+    delete_chunks_by_page, delete_doc_terms_by_page, update_page_content,
+    create_crawl_session, get_active_session_for_url, get_crawl_session,
+    update_session_status, update_session_stats, acquire_session_lock,
+    add_urls_to_crawl_queue, get_crawl_queue_urls, clear_crawl_queue
 )
 from rag_system.ingestion.crawler import Crawler
 from rag_system.ingestion.parser import parse_html, extract_title
@@ -299,8 +302,13 @@ class Indexer:
                         included_paths: Optional[List[str]] = None,
                         max_pages: int = 1000,
                         delay: float = 1.0,
-                        ignore_robots: bool = False) -> Dict[str, int]:
+                        ignore_robots: bool = False,
+                        fresh: bool = False) -> Dict[str, int]:
         """Crawl a website and index all pages.
+
+        Supports resuming interrupted crawls. If a previous crawl for the same
+        URL was interrupted, it will automatically resume from where it left off
+        unless fresh=True is specified.
 
         Args:
             start_url: Starting URL.
@@ -311,51 +319,128 @@ class Indexer:
             max_pages: Maximum pages to crawl.
             delay: Delay between requests.
             ignore_robots: If True, ignore robots.txt restrictions.
+            fresh: If True, start a new crawl even if a resumable session exists.
 
         Returns:
             Dict with crawl/index statistics.
         """
-        crawler = Crawler(
-            start_url=start_url,
-            allowed_domains=allowed_domains,
-            excluded_paths=excluded_paths or config.EXCLUDED_PATHS,
-            included_paths=included_paths or config.INCLUDED_PATHS,
-            max_pages=max_pages,
-            delay=delay,
-            cache_dir=os.environ.get('RAG_HTTP_CACHE_DIR'),
-            ignore_robots=ignore_robots
-        )
+        conn = get_connection(self.db_path)
+        session_id = None
+        resuming = False
 
-        pages_crawled = 0
-        pages_indexed = 0
-        pages_skipped = 0
-        errors = 0
+        try:
+            # Check for existing resumable session
+            if not fresh:
+                existing_session = get_active_session_for_url(conn, start_url)
+                if existing_session and existing_session['status'] == 'interrupted':
+                    # Try to acquire lock on the session
+                    if acquire_session_lock(conn, existing_session['id']):
+                        session_id = existing_session['id']
+                        resuming = True
+                        logger.info(f"Resuming interrupted session {session_id}")
 
-        for page_data in crawler.crawl():
-            pages_crawled += 1
+            # Create new session if not resuming
+            if session_id is None:
+                session_id = create_crawl_session(
+                    conn, start_url, allowed_domains, max_pages
+                )
+                logger.info(f"Created new crawl session {session_id}")
+
+            # Create crawler
+            crawler = Crawler(
+                start_url=start_url,
+                allowed_domains=allowed_domains,
+                excluded_paths=excluded_paths or config.EXCLUDED_PATHS,
+                included_paths=included_paths or config.INCLUDED_PATHS,
+                max_pages=max_pages,
+                delay=delay,
+                cache_dir=os.environ.get('RAG_HTTP_CACHE_DIR'),
+                ignore_robots=ignore_robots
+            )
+
+            # If resuming, load queue from database
+            if resuming:
+                queue_urls = get_crawl_queue_urls(conn, session_id)
+                if queue_urls:
+                    crawler.queue = list(queue_urls)
+                    logger.info(f"Loaded {len(queue_urls)} URLs from saved queue")
+                # Clear the queue in DB since we've loaded it into memory
+                clear_crawl_queue(conn, session_id)
+
+            pages_crawled = 0
+            pages_indexed = 0
+            pages_skipped = 0
+            errors = 0
+
             try:
-                page_id = self.index_page(page_data)
-                if page_id:
-                    pages_indexed += 1
-                else:
-                    pages_skipped += 1
-            except Exception as e:
-                logger.error(f"Error indexing {page_data.get('url')}: {e}")
-                errors += 1
+                for page_data in crawler.crawl():
+                    pages_crawled += 1
+                    try:
+                        page_id = self.index_page(page_data)
+                        if page_id:
+                            pages_indexed += 1
+                        else:
+                            pages_skipped += 1
+                    except Exception as e:
+                        logger.error(f"Error indexing {page_data.get('url')}: {e}")
+                        errors += 1
 
-        # Build BM25 index for search
-        from rag_system.search.bm25_search import BM25Index
-        logger.info("Building BM25 search index...")
-        bm25_index = BM25Index(self.db_path)
-        bm25_index.build()
-        logger.info("BM25 index built successfully")
+                    # Update session stats periodically
+                    if pages_crawled % 10 == 0:
+                        update_session_stats(
+                            conn, session_id,
+                            pages_crawled=pages_crawled,
+                            pages_indexed=pages_indexed,
+                            pages_skipped=pages_skipped,
+                            errors=errors
+                        )
 
-        return {
-            'pages_crawled': pages_crawled,
-            'pages_indexed': pages_indexed,
-            'pages_skipped': pages_skipped,
-            'errors': errors
-        }
+                # Crawl completed successfully
+                update_session_stats(
+                    conn, session_id,
+                    pages_crawled=pages_crawled,
+                    pages_indexed=pages_indexed,
+                    pages_skipped=pages_skipped,
+                    errors=errors
+                )
+                update_session_status(conn, session_id, 'completed')
+                logger.info(f"Crawl session {session_id} completed")
+
+            except KeyboardInterrupt:
+                # Save queue state for resume
+                logger.info("Crawl interrupted, saving state...")
+                if crawler.queue:
+                    add_urls_to_crawl_queue(conn, session_id, crawler.queue)
+                    logger.info(f"Saved {len(crawler.queue)} URLs to queue")
+                update_session_stats(
+                    conn, session_id,
+                    pages_crawled=pages_crawled,
+                    pages_indexed=pages_indexed,
+                    pages_skipped=pages_skipped,
+                    errors=errors
+                )
+                update_session_status(conn, session_id, 'interrupted')
+                logger.info(f"Crawl session {session_id} interrupted")
+                raise  # Re-raise to let caller handle
+
+            # Build BM25 index for search
+            from rag_system.search.bm25_search import BM25Index
+            logger.info("Building BM25 search index...")
+            bm25_index = BM25Index(self.db_path)
+            bm25_index.build()
+            logger.info("BM25 index built successfully")
+
+            return {
+                'pages_crawled': pages_crawled,
+                'pages_indexed': pages_indexed,
+                'pages_skipped': pages_skipped,
+                'errors': errors,
+                'session_id': session_id,
+                'resumed': resuming
+            }
+
+        finally:
+            conn.close()
 
     def get_stats(self) -> Dict[str, int]:
         """Get index statistics.

--- a/rag_system/main.py
+++ b/rag_system/main.py
@@ -132,6 +132,10 @@ def create_parser() -> argparse.ArgumentParser:
         '--ignore-robots', action='store_true',
         help='Ignore robots.txt restrictions (use responsibly)'
     )
+    ingest_parser.add_argument(
+        '--fresh', action='store_true',
+        help='Start a new crawl even if a resumable session exists'
+    )
 
     # Query command
     query_parser = subparsers.add_parser('query', help='Query the system')
@@ -184,6 +188,16 @@ def create_parser() -> argparse.ArgumentParser:
     backfill_parser.add_argument(
         '--batch-size', type=int, default=config.EMBEDDING_BATCH_SIZE,
         help='Number of chunks to embed per API call'
+    )
+
+    # Crawl sessions command
+    sessions_parser = subparsers.add_parser(
+        'crawl-sessions',
+        help='View and manage crawl sessions'
+    )
+    sessions_parser.add_argument(
+        '--json', action='store_true',
+        help='Output as JSON'
     )
 
     return parser
@@ -490,13 +504,18 @@ class RAGSystem:
         return result
 
     def ingest(self, start_url: str, max_pages: int = None,
-                ignore_robots: bool = False) -> Dict[str, Any]:
+                ignore_robots: bool = False, fresh: bool = False) -> Dict[str, Any]:
         """Ingest documentation from URL.
+
+        Supports resuming interrupted crawls. If a previous crawl for the same
+        URL was interrupted, it will automatically resume from where it left off
+        unless fresh=True is specified.
 
         Args:
             start_url: Starting URL to crawl.
             max_pages: Maximum pages to crawl.
             ignore_robots: If True, ignore robots.txt restrictions.
+            fresh: If True, start a new crawl even if a resumable session exists.
 
         Returns:
             Ingestion statistics.
@@ -523,7 +542,8 @@ class RAGSystem:
             included_paths=config.INCLUDED_PATHS,
             max_pages=max_pages,
             delay=config.CRAWL_DELAY_SECONDS,
-            ignore_robots=ignore_robots
+            ignore_robots=ignore_robots,
+            fresh=fresh
         )
 
     def get_stats(self) -> Dict[str, int]:
@@ -748,15 +768,19 @@ def main() -> None:
                 print(f"Ingesting from {args.url} (unlimited pages)...")
             else:
                 print(f"Ingesting from {args.url} (max {max_pages} pages)...")
+            if args.fresh:
+                print("Starting fresh crawl (ignoring any existing session)...")
             try:
                 stats = rag.ingest(
                     args.url,
                     max_pages=max_pages,
-                    ignore_robots=args.ignore_robots
+                    ignore_robots=args.ignore_robots,
+                    fresh=args.fresh
                 )
-                print(f"Crawled {stats['pages_crawled']} pages, indexed {stats['pages_indexed']}, skipped {stats['pages_skipped']}, errors: {stats['errors']}")
+                resumed_msg = " (resumed)" if stats.get('resumed') else ""
+                print(f"Crawled {stats['pages_crawled']} pages{resumed_msg}, indexed {stats['pages_indexed']}, skipped {stats['pages_skipped']}, errors: {stats['errors']}")
             except KeyboardInterrupt:
-                print("\nIngestion interrupted. Partial data may have been indexed.")
+                print("\nIngestion interrupted. Progress has been saved - run the same command to resume.")
                 logger.info("Ingestion interrupted by user")
 
         elif args.command == 'query':
@@ -862,6 +886,26 @@ def main() -> None:
                 rag.vector_client,
                 batch_size=args.batch_size
             )
+
+        elif args.command == 'crawl-sessions':
+            from rag_system.database import get_connection, list_crawl_sessions
+            conn = get_connection(args.db)
+            try:
+                sessions = list_crawl_sessions(conn)
+                if args.json:
+                    import json
+                    print(json.dumps(sessions, indent=2, default=str))
+                else:
+                    if not sessions:
+                        print("No crawl sessions found.")
+                    else:
+                        print(f"{'ID':<6} {'Status':<12} {'URL':<50} {'Pages':<8} {'Started'}")
+                        print("-" * 100)
+                        for s in sessions:
+                            started = s['started_at'][:19] if s['started_at'] else 'N/A'
+                            print(f"{s['id']:<6} {s['status']:<12} {s['start_url'][:50]:<50} {s['pages_crawled']:<8} {started}")
+            finally:
+                conn.close()
 
     except KeyboardInterrupt:
         print("\nShutdown requested")

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -45,7 +45,10 @@ Run this first! Checks your Python version, helps create a `.env` file with your
 ./scripts/crawl.sh https://docs.python.org/3/
 ./scripts/crawl.sh https://fastapi.tiangolo.com --max-pages 100
 ./scripts/crawl.sh https://example.com --ignore-robots  # Use responsibly!
+./scripts/crawl.sh https://example.com --fresh          # Start fresh crawl
 ```
+
+**Resume support:** If you interrupt a crawl with Ctrl+C, progress is saved automatically. Run the same command again to resume. Use `--fresh` to start over.
 
 ### query.sh
 ```bash

--- a/scripts/crawl.sh
+++ b/scripts/crawl.sh
@@ -13,11 +13,17 @@
 #   ./scripts/crawl.sh <url> --max-pages 100    # Limit to 100 pages
 #   ./scripts/crawl.sh <url> --unlimited        # Crawl ALL pages (no limit)
 #   ./scripts/crawl.sh <url> --ignore-robots    # Ignore robots.txt (use responsibly!)
+#   ./scripts/crawl.sh <url> --fresh            # Start fresh (ignore any saved session)
 #
 # EXAMPLES:
 #   ./scripts/crawl.sh https://docs.python.org/3/
 #   ./scripts/crawl.sh https://fastapi.tiangolo.com --max-pages 50
 #   ./scripts/crawl.sh https://docs.python.org/3.6/ --unlimited --ignore-robots
+#
+# RESUME SUPPORT:
+#   If you interrupt a crawl (Ctrl+C), the progress is automatically saved.
+#   Running the same command again will resume from where you left off.
+#   Use --fresh to discard any saved session and start over.
 #
 # REQUIREMENTS:
 #   - Python 3.6.5+

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -35,7 +35,8 @@ class TestDatabaseInit(unittest.TestCase):
             'pages', 'chunks', 'entities', 'relationships',
             'chunk_entities', 'systems', 'page_systems', 'global_summary',
             'doc_terms', 'corpus_stats', 'term_doc_frequencies',
-            'query_cache', 'query_log'
+            'query_cache', 'query_log',
+            'crawl_sessions', 'crawl_queue'
         }
 
         self.assertTrue(expected_tables.issubset(tables),
@@ -789,6 +790,464 @@ class TestAutoCommitParameter(unittest.TestCase):
 
         page = get_page_by_url(conn, 'https://example.com/commit')
         self.assertIsNotNone(page)
+        conn.close()
+
+
+class TestCrawlSessionSchema(unittest.TestCase):
+    """Test crawl session schema creation."""
+
+    def setUp(self):
+        """Create a temporary database for testing."""
+        self.temp_fd, self.temp_path = tempfile.mkstemp(suffix='.db')
+        os.close(self.temp_fd)
+
+    def tearDown(self):
+        """Remove temporary database."""
+        if os.path.exists(self.temp_path):
+            os.unlink(self.temp_path)
+
+    def test_init_db_creates_crawl_session_tables(self):
+        """init_db should create crawl_sessions and crawl_queue tables."""
+        from rag_system.database import init_db
+
+        init_db(self.temp_path)
+
+        conn = sqlite3.connect(self.temp_path)
+        cursor = conn.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        tables = {row[0] for row in cursor.fetchall()}
+
+        self.assertIn('crawl_sessions', tables)
+        self.assertIn('crawl_queue', tables)
+        conn.close()
+
+    def test_crawl_sessions_table_has_required_columns(self):
+        """crawl_sessions table should have all required columns."""
+        from rag_system.database import init_db
+
+        init_db(self.temp_path)
+
+        conn = sqlite3.connect(self.temp_path)
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA table_info(crawl_sessions)")
+        columns = {row[1] for row in cursor.fetchall()}
+
+        expected_columns = {
+            'id', 'start_url', 'allowed_domains', 'status',
+            'pages_crawled', 'pages_indexed', 'pages_skipped', 'errors',
+            'started_at', 'completed_at'
+        }
+        self.assertTrue(expected_columns.issubset(columns),
+                       f"Missing columns: {expected_columns - columns}")
+        conn.close()
+
+    def test_crawl_queue_table_has_required_columns(self):
+        """crawl_queue table should have all required columns."""
+        from rag_system.database import init_db
+
+        init_db(self.temp_path)
+
+        conn = sqlite3.connect(self.temp_path)
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA table_info(crawl_queue)")
+        columns = {row[1] for row in cursor.fetchall()}
+
+        expected_columns = {'id', 'session_id', 'url', 'depth', 'added_at'}
+        self.assertTrue(expected_columns.issubset(columns),
+                       f"Missing columns: {expected_columns - columns}")
+        conn.close()
+
+
+class TestCrawlSessionOperations(unittest.TestCase):
+    """Test crawl session CRUD operations."""
+
+    def setUp(self):
+        """Create a temporary database for testing."""
+        self.temp_fd, self.temp_path = tempfile.mkstemp(suffix='.db')
+        os.close(self.temp_fd)
+        from rag_system.database import init_db
+        init_db(self.temp_path)
+
+    def tearDown(self):
+        """Remove temporary database."""
+        if os.path.exists(self.temp_path):
+            os.unlink(self.temp_path)
+
+    def test_create_crawl_session(self):
+        """create_crawl_session should create a new session and return its ID."""
+        from rag_system.database import get_connection, create_crawl_session
+
+        conn = get_connection(self.temp_path)
+        session_id = create_crawl_session(
+            conn,
+            start_url='https://example.com',
+            allowed_domains=['example.com'],
+            max_pages=100
+        )
+
+        self.assertIsInstance(session_id, int)
+        self.assertGreater(session_id, 0)
+        conn.close()
+
+    def test_get_crawl_session(self):
+        """get_crawl_session should retrieve session by ID."""
+        from rag_system.database import get_connection, create_crawl_session, get_crawl_session
+
+        conn = get_connection(self.temp_path)
+        session_id = create_crawl_session(
+            conn,
+            start_url='https://example.com',
+            allowed_domains=['example.com'],
+            max_pages=100
+        )
+
+        session = get_crawl_session(conn, session_id)
+
+        self.assertIsNotNone(session)
+        self.assertEqual(session['start_url'], 'https://example.com')
+        self.assertEqual(session['status'], 'active')
+        self.assertEqual(session['pages_crawled'], 0)
+        conn.close()
+
+    def test_get_crawl_session_not_found(self):
+        """get_crawl_session should return None for non-existent session."""
+        from rag_system.database import get_connection, get_crawl_session
+
+        conn = get_connection(self.temp_path)
+        session = get_crawl_session(conn, 9999)
+
+        self.assertIsNone(session)
+        conn.close()
+
+    def test_get_active_session_for_url(self):
+        """get_active_session_for_url should find resumable session."""
+        from rag_system.database import (
+            get_connection, create_crawl_session,
+            update_session_status, get_active_session_for_url
+        )
+
+        conn = get_connection(self.temp_path)
+
+        # Create a session and mark it interrupted
+        session_id = create_crawl_session(
+            conn,
+            start_url='https://example.com',
+            allowed_domains=['example.com'],
+            max_pages=100
+        )
+        update_session_status(conn, session_id, 'interrupted')
+
+        # Should find the interrupted session
+        found = get_active_session_for_url(conn, 'https://example.com')
+
+        self.assertIsNotNone(found)
+        self.assertEqual(found['id'], session_id)
+        conn.close()
+
+    def test_get_active_session_for_url_no_match(self):
+        """get_active_session_for_url should return None when no session exists."""
+        from rag_system.database import get_connection, get_active_session_for_url
+
+        conn = get_connection(self.temp_path)
+        found = get_active_session_for_url(conn, 'https://nonexistent.com')
+
+        self.assertIsNone(found)
+        conn.close()
+
+    def test_get_active_session_ignores_completed(self):
+        """get_active_session_for_url should not return completed sessions."""
+        from rag_system.database import (
+            get_connection, create_crawl_session,
+            update_session_status, get_active_session_for_url
+        )
+
+        conn = get_connection(self.temp_path)
+
+        session_id = create_crawl_session(
+            conn,
+            start_url='https://example.com',
+            allowed_domains=['example.com'],
+            max_pages=100
+        )
+        update_session_status(conn, session_id, 'completed')
+
+        found = get_active_session_for_url(conn, 'https://example.com')
+
+        self.assertIsNone(found)
+        conn.close()
+
+    def test_update_session_status(self):
+        """update_session_status should change session status."""
+        from rag_system.database import (
+            get_connection, create_crawl_session,
+            update_session_status, get_crawl_session
+        )
+
+        conn = get_connection(self.temp_path)
+        session_id = create_crawl_session(
+            conn,
+            start_url='https://example.com',
+            allowed_domains=['example.com'],
+            max_pages=100
+        )
+
+        update_session_status(conn, session_id, 'completed')
+
+        session = get_crawl_session(conn, session_id)
+        self.assertEqual(session['status'], 'completed')
+        conn.close()
+
+    def test_update_session_stats(self):
+        """update_session_stats should update crawl statistics."""
+        from rag_system.database import (
+            get_connection, create_crawl_session,
+            update_session_stats, get_crawl_session
+        )
+
+        conn = get_connection(self.temp_path)
+        session_id = create_crawl_session(
+            conn,
+            start_url='https://example.com',
+            allowed_domains=['example.com'],
+            max_pages=100
+        )
+
+        update_session_stats(
+            conn, session_id,
+            pages_crawled=50,
+            pages_indexed=45,
+            pages_skipped=5,
+            errors=2
+        )
+
+        session = get_crawl_session(conn, session_id)
+        self.assertEqual(session['pages_crawled'], 50)
+        self.assertEqual(session['pages_indexed'], 45)
+        self.assertEqual(session['pages_skipped'], 5)
+        self.assertEqual(session['errors'], 2)
+        conn.close()
+
+    def test_list_crawl_sessions(self):
+        """list_crawl_sessions should return all sessions."""
+        from rag_system.database import (
+            get_connection, create_crawl_session, list_crawl_sessions
+        )
+
+        conn = get_connection(self.temp_path)
+        create_crawl_session(conn, 'https://a.com', ['a.com'], 100)
+        create_crawl_session(conn, 'https://b.com', ['b.com'], 200)
+
+        sessions = list_crawl_sessions(conn)
+
+        self.assertEqual(len(sessions), 2)
+        conn.close()
+
+
+class TestCrawlQueueOperations(unittest.TestCase):
+    """Test crawl queue operations."""
+
+    def setUp(self):
+        """Create a temporary database with a session for testing."""
+        self.temp_fd, self.temp_path = tempfile.mkstemp(suffix='.db')
+        os.close(self.temp_fd)
+        from rag_system.database import init_db, get_connection, create_crawl_session
+        init_db(self.temp_path)
+        conn = get_connection(self.temp_path)
+        self.session_id = create_crawl_session(
+            conn, 'https://example.com', ['example.com'], 100
+        )
+        conn.close()
+
+    def tearDown(self):
+        """Remove temporary database."""
+        if os.path.exists(self.temp_path):
+            os.unlink(self.temp_path)
+
+    def test_add_urls_to_crawl_queue(self):
+        """add_urls_to_crawl_queue should add URLs to the queue."""
+        from rag_system.database import (
+            get_connection, add_urls_to_crawl_queue, get_crawl_queue_size
+        )
+
+        conn = get_connection(self.temp_path)
+        urls = ['https://example.com/a', 'https://example.com/b']
+        add_urls_to_crawl_queue(conn, self.session_id, urls)
+
+        size = get_crawl_queue_size(conn, self.session_id)
+        self.assertEqual(size, 2)
+        conn.close()
+
+    def test_add_urls_to_crawl_queue_with_depth(self):
+        """add_urls_to_crawl_queue should store depth."""
+        from rag_system.database import (
+            get_connection, add_urls_to_crawl_queue, pop_from_crawl_queue
+        )
+
+        conn = get_connection(self.temp_path)
+        add_urls_to_crawl_queue(
+            conn, self.session_id,
+            ['https://example.com/deep'],
+            depth=3
+        )
+
+        url, depth = pop_from_crawl_queue(conn, self.session_id)
+        self.assertEqual(depth, 3)
+        conn.close()
+
+    def test_add_urls_ignores_duplicates(self):
+        """add_urls_to_crawl_queue should ignore duplicate URLs."""
+        from rag_system.database import (
+            get_connection, add_urls_to_crawl_queue, get_crawl_queue_size
+        )
+
+        conn = get_connection(self.temp_path)
+        add_urls_to_crawl_queue(conn, self.session_id, ['https://example.com/a'])
+        add_urls_to_crawl_queue(conn, self.session_id, ['https://example.com/a'])
+
+        size = get_crawl_queue_size(conn, self.session_id)
+        self.assertEqual(size, 1)
+        conn.close()
+
+    def test_pop_from_crawl_queue(self):
+        """pop_from_crawl_queue should return and remove the oldest URL."""
+        from rag_system.database import (
+            get_connection, add_urls_to_crawl_queue,
+            pop_from_crawl_queue, get_crawl_queue_size
+        )
+
+        conn = get_connection(self.temp_path)
+        add_urls_to_crawl_queue(
+            conn, self.session_id,
+            ['https://example.com/first', 'https://example.com/second']
+        )
+
+        url, depth = pop_from_crawl_queue(conn, self.session_id)
+
+        self.assertEqual(url, 'https://example.com/first')
+        self.assertEqual(get_crawl_queue_size(conn, self.session_id), 1)
+        conn.close()
+
+    def test_pop_from_crawl_queue_empty(self):
+        """pop_from_crawl_queue should return None when queue is empty."""
+        from rag_system.database import get_connection, pop_from_crawl_queue
+
+        conn = get_connection(self.temp_path)
+        result = pop_from_crawl_queue(conn, self.session_id)
+
+        self.assertIsNone(result)
+        conn.close()
+
+    def test_pop_from_crawl_queue_fifo_order(self):
+        """pop_from_crawl_queue should maintain FIFO order."""
+        from rag_system.database import (
+            get_connection, add_urls_to_crawl_queue, pop_from_crawl_queue
+        )
+
+        conn = get_connection(self.temp_path)
+        urls = [f'https://example.com/{i}' for i in range(5)]
+        add_urls_to_crawl_queue(conn, self.session_id, urls)
+
+        popped = []
+        for _ in range(5):
+            url, _ = pop_from_crawl_queue(conn, self.session_id)
+            popped.append(url)
+
+        self.assertEqual(popped, urls)
+        conn.close()
+
+    def test_get_crawl_queue_urls(self):
+        """get_crawl_queue_urls should return all URLs in queue."""
+        from rag_system.database import (
+            get_connection, add_urls_to_crawl_queue, get_crawl_queue_urls
+        )
+
+        conn = get_connection(self.temp_path)
+        urls = ['https://example.com/a', 'https://example.com/b']
+        add_urls_to_crawl_queue(conn, self.session_id, urls)
+
+        queue_urls = get_crawl_queue_urls(conn, self.session_id)
+
+        self.assertEqual(set(queue_urls), set(urls))
+        conn.close()
+
+    def test_clear_crawl_queue(self):
+        """clear_crawl_queue should remove all URLs from queue."""
+        from rag_system.database import (
+            get_connection, add_urls_to_crawl_queue,
+            clear_crawl_queue, get_crawl_queue_size
+        )
+
+        conn = get_connection(self.temp_path)
+        add_urls_to_crawl_queue(conn, self.session_id, ['https://example.com/a'])
+
+        clear_crawl_queue(conn, self.session_id)
+
+        size = get_crawl_queue_size(conn, self.session_id)
+        self.assertEqual(size, 0)
+        conn.close()
+
+
+class TestCrawlSessionLocking(unittest.TestCase):
+    """Test crawl session locking mechanism."""
+
+    def setUp(self):
+        """Create a temporary database for testing."""
+        self.temp_fd, self.temp_path = tempfile.mkstemp(suffix='.db')
+        os.close(self.temp_fd)
+        from rag_system.database import init_db, get_connection, create_crawl_session
+        init_db(self.temp_path)
+        conn = get_connection(self.temp_path)
+        self.session_id = create_crawl_session(
+            conn, 'https://example.com', ['example.com'], 100
+        )
+        conn.close()
+
+    def tearDown(self):
+        """Remove temporary database."""
+        if os.path.exists(self.temp_path):
+            os.unlink(self.temp_path)
+
+    def test_acquire_session_lock_succeeds_for_interrupted(self):
+        """acquire_session_lock should succeed for interrupted session."""
+        from rag_system.database import (
+            get_connection, update_session_status, acquire_session_lock
+        )
+
+        conn = get_connection(self.temp_path)
+        update_session_status(conn, self.session_id, 'interrupted')
+
+        success = acquire_session_lock(conn, self.session_id)
+
+        self.assertTrue(success)
+        conn.close()
+
+    def test_acquire_session_lock_fails_for_active(self):
+        """acquire_session_lock should fail if session is already active."""
+        from rag_system.database import get_connection, acquire_session_lock
+
+        conn = get_connection(self.temp_path)
+
+        # Session is already 'active' from creation
+        success = acquire_session_lock(conn, self.session_id)
+
+        self.assertFalse(success)
+        conn.close()
+
+    def test_release_session_lock(self):
+        """release_session_lock should mark session as interrupted."""
+        from rag_system.database import (
+            get_connection, update_session_status,
+            acquire_session_lock, release_session_lock, get_crawl_session
+        )
+
+        conn = get_connection(self.temp_path)
+        update_session_status(conn, self.session_id, 'interrupted')
+        acquire_session_lock(conn, self.session_id)
+
+        release_session_lock(conn, self.session_id)
+
+        session = get_crawl_session(conn, self.session_id)
+        self.assertEqual(session['status'], 'interrupted')
         conn.close()
 
 

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -278,5 +278,269 @@ class TestIndexStats(unittest.TestCase):
         self.assertGreater(stats['total_chunks'], 0)
 
 
+class TestCrawlSessionIntegration(unittest.TestCase):
+    """Test crawl session integration with indexer."""
+
+    def setUp(self):
+        """Create temporary database for testing."""
+        self.temp_fd, self.temp_path = tempfile.mkstemp(suffix='.db')
+        os.close(self.temp_fd)
+        from rag_system.database import init_db
+        init_db(self.temp_path)
+
+    def tearDown(self):
+        """Remove temporary database."""
+        if os.path.exists(self.temp_path):
+            os.unlink(self.temp_path)
+
+    def test_crawl_and_index_creates_session(self):
+        """crawl_and_index should create a crawl session."""
+        from rag_system.ingestion.indexer import Indexer
+        from rag_system.database import get_connection, list_crawl_sessions
+
+        indexer = Indexer(self.temp_path)
+
+        # Mock crawler to return one page
+        def mock_crawl_generator():
+            yield {
+                'url': 'https://example.com',
+                'html': '<html><body>Test</body></html>',
+                'status_code': 200
+            }
+
+        with patch('rag_system.ingestion.indexer.Crawler') as MockCrawler:
+            mock_crawler = MagicMock()
+            mock_crawler.crawl.return_value = mock_crawl_generator()
+            mock_crawler.queue = []
+            mock_crawler.visited = {'https://example.com'}
+            MockCrawler.return_value = mock_crawler
+
+            indexer.crawl_and_index(
+                start_url='https://example.com',
+                allowed_domains=['example.com'],
+                max_pages=10
+            )
+
+        conn = get_connection(self.temp_path)
+        sessions = list_crawl_sessions(conn)
+        conn.close()
+
+        self.assertEqual(len(sessions), 1)
+        self.assertEqual(sessions[0]['start_url'], 'https://example.com')
+
+    def test_crawl_and_index_marks_session_completed(self):
+        """crawl_and_index should mark session as completed when done."""
+        from rag_system.ingestion.indexer import Indexer
+        from rag_system.database import get_connection, list_crawl_sessions
+
+        indexer = Indexer(self.temp_path)
+
+        def mock_crawl_generator():
+            yield {
+                'url': 'https://example.com',
+                'html': '<html><body>Test</body></html>',
+                'status_code': 200
+            }
+
+        with patch('rag_system.ingestion.indexer.Crawler') as MockCrawler:
+            mock_crawler = MagicMock()
+            mock_crawler.crawl.return_value = mock_crawl_generator()
+            mock_crawler.queue = []
+            mock_crawler.visited = {'https://example.com'}
+            MockCrawler.return_value = mock_crawler
+
+            indexer.crawl_and_index(
+                start_url='https://example.com',
+                allowed_domains=['example.com'],
+                max_pages=10
+            )
+
+        conn = get_connection(self.temp_path)
+        sessions = list_crawl_sessions(conn)
+        conn.close()
+
+        self.assertEqual(sessions[0]['status'], 'completed')
+
+    def test_crawl_and_index_resumes_interrupted_session(self):
+        """crawl_and_index should resume an interrupted session."""
+        from rag_system.ingestion.indexer import Indexer
+        from rag_system.database import (
+            get_connection, create_crawl_session, update_session_status,
+            add_urls_to_crawl_queue, get_crawl_session
+        )
+
+        # Create an interrupted session with URLs in queue
+        conn = get_connection(self.temp_path)
+        session_id = create_crawl_session(
+            conn, 'https://example.com', ['example.com'], 100
+        )
+        update_session_status(conn, session_id, 'interrupted')
+        add_urls_to_crawl_queue(conn, session_id, [
+            'https://example.com/page1',
+            'https://example.com/page2'
+        ])
+        conn.close()
+
+        indexer = Indexer(self.temp_path)
+
+        pages_yielded = []
+
+        def mock_crawl_generator():
+            for url in ['https://example.com/page1', 'https://example.com/page2']:
+                pages_yielded.append(url)
+                yield {
+                    'url': url,
+                    'html': '<html><body>Test</body></html>',
+                    'status_code': 200
+                }
+
+        with patch('rag_system.ingestion.indexer.Crawler') as MockCrawler:
+            mock_crawler = MagicMock()
+            mock_crawler.crawl.return_value = mock_crawl_generator()
+            mock_crawler.queue = []
+            mock_crawler.visited = set()
+            MockCrawler.return_value = mock_crawler
+
+            result = indexer.crawl_and_index(
+                start_url='https://example.com',
+                allowed_domains=['example.com'],
+                max_pages=100
+            )
+
+        # Should have resumed the existing session
+        conn = get_connection(self.temp_path)
+        session = get_crawl_session(conn, session_id)
+        conn.close()
+
+        self.assertEqual(session['status'], 'completed')
+
+    def test_crawl_and_index_fresh_ignores_existing_session(self):
+        """crawl_and_index with fresh=True should start a new session."""
+        from rag_system.ingestion.indexer import Indexer
+        from rag_system.database import (
+            get_connection, create_crawl_session, update_session_status,
+            list_crawl_sessions
+        )
+
+        # Create an interrupted session
+        conn = get_connection(self.temp_path)
+        session_id = create_crawl_session(
+            conn, 'https://example.com', ['example.com'], 100
+        )
+        update_session_status(conn, session_id, 'interrupted')
+        conn.close()
+
+        indexer = Indexer(self.temp_path)
+
+        def mock_crawl_generator():
+            yield {
+                'url': 'https://example.com',
+                'html': '<html><body>Test</body></html>',
+                'status_code': 200
+            }
+
+        with patch('rag_system.ingestion.indexer.Crawler') as MockCrawler:
+            mock_crawler = MagicMock()
+            mock_crawler.crawl.return_value = mock_crawl_generator()
+            mock_crawler.queue = []
+            mock_crawler.visited = {'https://example.com'}
+            MockCrawler.return_value = mock_crawler
+
+            indexer.crawl_and_index(
+                start_url='https://example.com',
+                allowed_domains=['example.com'],
+                max_pages=10,
+                fresh=True
+            )
+
+        conn = get_connection(self.temp_path)
+        sessions = list_crawl_sessions(conn)
+        conn.close()
+
+        # Should have two sessions (old interrupted + new completed)
+        self.assertEqual(len(sessions), 2)
+        # Most recent should be completed
+        self.assertEqual(sessions[0]['status'], 'completed')
+
+    def test_crawl_and_index_updates_session_stats(self):
+        """crawl_and_index should update session statistics."""
+        from rag_system.ingestion.indexer import Indexer
+        from rag_system.database import get_connection, list_crawl_sessions
+
+        indexer = Indexer(self.temp_path)
+
+        def mock_crawl_generator():
+            for i in range(3):
+                yield {
+                    'url': f'https://example.com/page{i}',
+                    'html': '<html><body>Test content</body></html>',
+                    'status_code': 200
+                }
+
+        with patch('rag_system.ingestion.indexer.Crawler') as MockCrawler:
+            mock_crawler = MagicMock()
+            mock_crawler.crawl.return_value = mock_crawl_generator()
+            mock_crawler.queue = []
+            mock_crawler.visited = set()
+            MockCrawler.return_value = mock_crawler
+
+            indexer.crawl_and_index(
+                start_url='https://example.com',
+                allowed_domains=['example.com'],
+                max_pages=10
+            )
+
+        conn = get_connection(self.temp_path)
+        sessions = list_crawl_sessions(conn)
+        conn.close()
+
+        self.assertEqual(sessions[0]['pages_crawled'], 3)
+        self.assertGreaterEqual(sessions[0]['pages_indexed'], 0)
+
+    def test_crawl_and_index_saves_queue_on_interrupt(self):
+        """crawl_and_index should save queue when interrupted."""
+        from rag_system.ingestion.indexer import Indexer
+        from rag_system.database import (
+            get_connection, list_crawl_sessions, get_crawl_queue_urls
+        )
+
+        indexer = Indexer(self.temp_path)
+
+        # Simulate an interrupted crawl
+        def mock_crawl_generator():
+            yield {
+                'url': 'https://example.com',
+                'html': '<html><body>Test</body></html>',
+                'status_code': 200
+            }
+            # Simulate interrupt after first page
+            raise KeyboardInterrupt()
+
+        with patch('rag_system.ingestion.indexer.Crawler') as MockCrawler:
+            mock_crawler = MagicMock()
+            mock_crawler.crawl.return_value = mock_crawl_generator()
+            mock_crawler.queue = ['https://example.com/page1', 'https://example.com/page2']
+            mock_crawler.visited = {'https://example.com'}
+            MockCrawler.return_value = mock_crawler
+
+            try:
+                indexer.crawl_and_index(
+                    start_url='https://example.com',
+                    allowed_domains=['example.com'],
+                    max_pages=10
+                )
+            except KeyboardInterrupt:
+                pass  # Expected
+
+        conn = get_connection(self.temp_path)
+        sessions = list_crawl_sessions(conn)
+        # Queue should be saved
+        queue_urls = get_crawl_queue_urls(conn, sessions[0]['id'])
+        conn.close()
+
+        self.assertEqual(sessions[0]['status'], 'interrupted')
+        self.assertEqual(len(queue_urls), 2)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -239,5 +239,112 @@ class TestIngestOutput(unittest.TestCase):
             self.assertNotIn('Ingested 0 pages', output)  # Bug 2 check - old buggy format
 
 
+class TestCrawlSessionCLI(unittest.TestCase):
+    """Test crawl session CLI commands."""
+
+    def setUp(self):
+        """Set up test database."""
+        self.temp_fd, self.temp_path = tempfile.mkstemp(suffix='.db')
+        os.close(self.temp_fd)
+        from rag_system.database import init_db
+        init_db(self.temp_path)
+
+    def tearDown(self):
+        """Clean up test database."""
+        os.unlink(self.temp_path)
+
+    def test_ingest_fresh_flag_parsed(self):
+        """Parser should recognize --fresh flag."""
+        from rag_system.main import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(['ingest', 'https://example.com', '--fresh'])
+
+        self.assertTrue(args.fresh)
+
+    def test_ingest_fresh_flag_default_false(self):
+        """Parser should default --fresh to False."""
+        from rag_system.main import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(['ingest', 'https://example.com'])
+
+        self.assertFalse(args.fresh)
+
+    def test_ingest_passes_fresh_to_indexer(self):
+        """ingest command should pass fresh flag to indexer."""
+        from rag_system.main import RAGSystem
+        from rag_system.ingestion.indexer import Indexer
+
+        rag = RAGSystem(db_path=self.temp_path)
+
+        with patch.object(Indexer, 'crawl_and_index') as mock_crawl:
+            mock_crawl.return_value = {
+                'pages_crawled': 1,
+                'pages_indexed': 1,
+                'pages_skipped': 0,
+                'errors': 0
+            }
+
+            rag.ingest('https://example.com', max_pages=10, fresh=True)
+
+            mock_crawl.assert_called_once()
+            call_kwargs = mock_crawl.call_args[1]
+            self.assertTrue(call_kwargs.get('fresh', False))
+
+    def test_crawl_sessions_command_exists(self):
+        """Parser should have crawl-sessions command."""
+        from rag_system.main import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(['crawl-sessions'])
+
+        self.assertEqual(args.command, 'crawl-sessions')
+
+    def test_crawl_sessions_list(self):
+        """crawl-sessions should list sessions."""
+        from rag_system.main import main
+        from rag_system.database import get_connection, create_crawl_session
+        from io import StringIO
+
+        # Create a session
+        conn = get_connection(self.temp_path)
+        create_crawl_session(conn, 'https://example.com', ['example.com'], 100)
+        conn.close()
+
+        test_args = ['rag_system', '--db', self.temp_path, 'crawl-sessions']
+
+        with patch('sys.argv', test_args), \
+             patch('sys.stdout', new=StringIO()) as fake_out:
+            main()
+            output = fake_out.getvalue()
+
+            self.assertIn('https://example.com', output)
+
+    def test_crawl_sessions_json_output(self):
+        """crawl-sessions --json should output JSON."""
+        from rag_system.main import main
+        from rag_system.database import get_connection, create_crawl_session
+        from io import StringIO
+        import json
+
+        conn = get_connection(self.temp_path)
+        create_crawl_session(conn, 'https://example.com', ['example.com'], 100)
+        conn.close()
+
+        test_args = ['rag_system', '--db', self.temp_path, 'crawl-sessions', '--json']
+
+        with patch('sys.argv', test_args), \
+             patch('sys.stdout', new=StringIO()) as fake_out:
+            main()
+            output = fake_out.getvalue()
+
+            # Should be valid JSON
+            data = json.loads(output)
+            self.assertIsInstance(data, list)
+            self.assertEqual(len(data), 1)
+            self.assertEqual(data[0]['start_url'], 'https://example.com')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- Adds database-backed crawl session management to enable resuming interrupted crawls
- When a crawl is interrupted (Ctrl+C), queue state and progress are automatically saved
- Running the same command again resumes from where it left off
- Use `--fresh` flag to start a new crawl instead of resuming

## Changes
- **Database**: Added `crawl_sessions` and `crawl_queue` tables with 10 CRUD functions
- **Indexer**: Session lifecycle management (create/resume/complete/interrupt)
- **CLI**: Added `--fresh` flag and `crawl-sessions` command

## Test plan
- [x] Run `./scripts/crawl.sh https://docs.python.org/3/ --max-pages 10`
- [x] Ctrl+C after a few pages
- [x] Run the same command - should resume from saved queue
- [x] Run with `--fresh` flag - should start over
- [x] Run `python -m rag_system.main crawl-sessions` to view sessions

## Tests added
- 23 new database tests for session/queue CRUD
- 6 new indexer integration tests for resume flow
- 6 new CLI tests for --fresh and crawl-sessions

All 650 tests pass.

Fixes #50

🤖 Generated with [Claude Code](https://claude.ai/code)