### PR TITLE
fix: replace MD5 with SHA256 for FIPS compliance

### DIFF
--- a/rag_system/ingestion/crawler.py
+++ b/rag_system/ingestion/crawler.py
@@ -296,7 +296,7 @@ class HTTPCache:
         Returns:
             Path to cache file.
         """
-        url_hash = hashlib.md5(url.encode()).hexdigest()
+        url_hash = hashlib.sha256(url.encode()).hexdigest()
         return os.path.join(self.cache_dir, f"{url_hash}.json")
 
     def get(self, url: str) -> Optional[Tuple[str, int]]:

--- a/rag_system/main.py
+++ b/rag_system/main.py
@@ -365,8 +365,8 @@ class RAGSystem:
 
         top_k = top_k or config.TOP_K_FINAL
 
-        # Generate query hash for caching
-        query_hash = hashlib.md5(question.lower().strip().encode()).hexdigest()
+        # Generate query hash for caching (SHA256 for FIPS compliance)
+        query_hash = hashlib.sha256(question.lower().strip().encode()).hexdigest()
 
         # Check query result cache first
         cache_key = f"{query_hash}:{top_k}"

--- a/rag_system/search/vector_search.py
+++ b/rag_system/search/vector_search.py
@@ -242,7 +242,7 @@ class VectorSearch:
         """Compute a hash of the current database content.
 
         Returns:
-            MD5 hash of chunk IDs and embedding update timestamps.
+            SHA256 hash of chunk IDs and embedding update timestamps.
         """
         conn = get_connection(self.db_path)
         try:
@@ -259,7 +259,7 @@ class VectorSearch:
 
             # Create hash from content signature
             signature = f"{count}:{max_id}:{self.db_path}"
-            return hashlib.md5(signature.encode()).hexdigest()
+            return hashlib.sha256(signature.encode()).hexdigest()
         finally:
             conn.close()
 

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -622,7 +622,7 @@ class TestHTTPCache(unittest.TestCase):
 
         cache = HTTPCache(self.temp_dir)
         url = 'https://example.com/corrupted'
-        url_hash = hashlib.md5(url.encode()).hexdigest()
+        url_hash = hashlib.sha256(url.encode()).hexdigest()
         cache_path = os.path.join(self.temp_dir, f"{url_hash}.json")
 
         # Write corrupted JSON
@@ -644,7 +644,7 @@ class TestHTTPCache(unittest.TestCase):
 
         cache = HTTPCache(self.temp_dir)
         url = 'https://example.com/empty'
-        url_hash = hashlib.md5(url.encode()).hexdigest()
+        url_hash = hashlib.sha256(url.encode()).hexdigest()
         cache_path = os.path.join(self.temp_dir, f"{url_hash}.json")
 
         # Write empty file
@@ -665,7 +665,7 @@ class TestHTTPCache(unittest.TestCase):
 
         cache = HTTPCache(self.temp_dir)
         url = 'https://example.com/incomplete'
-        url_hash = hashlib.md5(url.encode()).hexdigest()
+        url_hash = hashlib.sha256(url.encode()).hexdigest()
         cache_path = os.path.join(self.temp_dir, f"{url_hash}.json")
 
         # Write JSON with missing required fields


### PR DESCRIPTION
## Summary
Replaces all MD5 hashing with SHA256 to fix FIPS compliance errors.

## Changes
- **rag_system/main.py**: Query hash for caching now uses SHA256
- **rag_system/ingestion/crawler.py**: URL cache hash uses SHA256
- **rag_system/search/vector_search.py**: Content hash for index validation uses SHA256
- **tests/test_crawler.py**: Updated test assertions to match

## Why
MD5 is not FIPS-approved and causes errors on FIPS-enabled systems. SHA256 is FIPS-compliant and provides stronger hashing.

## Testing
All 77 tests pass ✅