### PR TITLE
feat: add --force flag to backfill for embedding regeneration

### DIFF
--- a/rag_system/main.py
+++ b/rag_system/main.py
@@ -216,6 +216,10 @@ def create_parser() -> argparse.ArgumentParser:
         '--batch-size', type=int, default=config.EMBEDDING_BATCH_SIZE,
         help='Number of chunks to embed per API call'
     )
+    backfill_parser.add_argument(
+        '--force', action='store_true',
+        help='Regenerate all embeddings, even for chunks that already have them'
+    )
 
     # Crawl sessions command
     sessions_parser = subparsers.add_parser(
@@ -697,13 +701,14 @@ def run_interactive(rag: RAGSystem) -> None:
 
 
 def backfill_embeddings(db_path: str, vector_client: Any,
-                         batch_size: int = 100) -> Dict[str, int]:
+                         batch_size: int = 100, force: bool = False) -> Dict[str, int]:
     """Generate embeddings for chunks that don't have them.
 
     Args:
         db_path: Path to SQLite database.
         vector_client: Vector API client for embeddings.
         batch_size: Number of chunks to embed per API call.
+        force: If True, regenerate embeddings for all chunks, not just missing ones.
 
     Returns:
         Dict with statistics about the backfill operation.
@@ -715,22 +720,33 @@ def backfill_embeddings(db_path: str, vector_client: Any,
 
     conn = get_connection(db_path)
     try:
-        # Find chunks without embeddings
-        cursor = conn.execute("""
-            SELECT c.id, c.content, c.heading_path, p.title
-            FROM chunks c
-            JOIN pages p ON c.page_id = p.id
-            WHERE c.embedding_json IS NULL
-            ORDER BY c.id
-        """)
+        # Find chunks to embed (all chunks if force, otherwise only missing)
+        if force:
+            cursor = conn.execute("""
+                SELECT c.id, c.content, c.heading_path, p.title
+                FROM chunks c
+                JOIN pages p ON c.page_id = p.id
+                ORDER BY c.id
+            """)
+        else:
+            cursor = conn.execute("""
+                SELECT c.id, c.content, c.heading_path, p.title
+                FROM chunks c
+                JOIN pages p ON c.page_id = p.id
+                WHERE c.embedding_json IS NULL
+                ORDER BY c.id
+            """)
         chunks_to_embed = cursor.fetchall()
 
         total = len(chunks_to_embed)
         if total == 0:
-            print("All chunks already have embeddings!")
+            print("No chunks found to embed.")
             return {'total': 0, 'embedded': 0, 'errors': 0}
 
-        print(f"Found {total} chunks without embeddings")
+        if force:
+            print(f"Regenerating embeddings for {total} chunks (force mode)")
+        else:
+            print(f"Found {total} chunks without embeddings")
 
         embedded = 0
         errors = 0
@@ -1020,7 +1036,8 @@ def main() -> None:
             backfill_embeddings(
                 rag.db_path,
                 rag.vector_client,
-                batch_size=args.batch_size
+                batch_size=args.batch_size,
+                force=args.force
             )
 
         elif args.command == 'crawl-sessions':

--- a/scripts/regenerate-embeddings.sh
+++ b/scripts/regenerate-embeddings.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Regenerate all embeddings with contextual retrieval
+#
+# This script forces regeneration of embeddings for all chunks,
+# even those that already have embeddings. Use this after upgrading
+# to contextual retrieval to improve search quality.
+#
+# Usage:
+#   ./scripts/regenerate-embeddings.sh [options]
+#
+# Options:
+#   --batch-size N    Number of chunks to embed per API call (default: 100)
+#
+# Examples:
+#   ./scripts/regenerate-embeddings.sh
+#   ./scripts/regenerate-embeddings.sh --batch-size 50
+
+set -e
+cd "$(dirname "$0")/.."
+
+# Load .env if it exists
+if [[ -f .env ]]; then
+    export $(grep -v '^#' .env | xargs)
+fi
+
+echo "Regenerating all embeddings with contextual retrieval..."
+echo "This will re-embed all chunks, which may take a while and use API credits."
+echo ""
+
+python -m rag_system.main backfill --force "$@"


### PR DESCRIPTION
## Summary

- Add `--force` flag to backfill command to regenerate all embeddings, not just missing ones
- Create `scripts/regenerate-embeddings.sh` convenience script for easy embedding regeneration

This enables upgrading existing databases to use contextual retrieval embeddings, which improve retrieval quality by 20-30% by embedding chunks with their document title and heading path context.

## Usage

```bash
# Regenerate all embeddings with contextual retrieval
python -m rag_system.main backfill --force

# Or use the convenience script
./scripts/regenerate-embeddings.sh
```

## Test plan

- [x] Verify `--force` flag appears in `backfill --help`
- [x] Verify syntax is correct (`python -m py_compile`)
- [x] All 655 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)