### PR TITLE
feat: Add knowledge graph context to answer generation

### DIFF
--- a/rag_system/query/context_builder.py
+++ b/rag_system/query/context_builder.py
@@ -1,11 +1,12 @@
 """Context builder module for the RAG system.
 
-Builds context from retrieved chunks for answer generation.
+Builds context from retrieved chunks for answer generation, including
+knowledge graph context when available.
 """
 
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any, Optional, Set
 
-from rag_system.database import get_connection, get_chunk_by_id
+from rag_system.database import get_connection, get_chunk_by_id, get_entities_for_chunk
 from rag_system.utils import get_logger
 
 logger = get_logger(__name__)
@@ -117,6 +118,97 @@ class ContextBuilder:
         finally:
             conn.close()
 
+    def get_entity_context(self, chunk_ids: List[int]) -> Dict[str, Any]:
+        """Get entities and relationships related to chunks.
+
+        Args:
+            chunk_ids: List of chunk IDs to get entities for.
+
+        Returns:
+            Dict with 'entities' list and 'relationships' list.
+        """
+        if not self.db_path or not chunk_ids:
+            return {'entities': [], 'relationships': []}
+
+        conn = get_connection(self.db_path)
+        try:
+            # Collect unique entities from all chunks
+            entities: Dict[int, Dict[str, Any]] = {}
+            entity_ids: Set[int] = set()
+
+            for chunk_id in chunk_ids:
+                chunk_entities = get_entities_for_chunk(conn, chunk_id)
+                for entity in chunk_entities:
+                    entity_id = entity['id']
+                    if entity_id not in entities:
+                        entities[entity_id] = entity
+                        entity_ids.add(entity_id)
+
+            # Get relationships between collected entities
+            relationships = []
+            if entity_ids:
+                placeholders = ','.join('?' * len(entity_ids))
+                cursor = conn.execute(
+                    f"""SELECT r.*, 
+                               e1.name as source_name, 
+                               e2.name as target_name
+                        FROM relationships r
+                        JOIN entities e1 ON r.source_entity_id = e1.id
+                        JOIN entities e2 ON r.target_entity_id = e2.id
+                        WHERE r.source_entity_id IN ({placeholders})
+                          AND r.target_entity_id IN ({placeholders})""",
+                    tuple(entity_ids) + tuple(entity_ids)
+                )
+                for row in cursor.fetchall():
+                    relationships.append({
+                        'source': row['source_name'],
+                        'target': row['target_name'],
+                        'type': row['relationship_type'],
+                        'description': row['description']
+                    })
+
+            return {
+                'entities': list(entities.values()),
+                'relationships': relationships
+            }
+        finally:
+            conn.close()
+
+    def format_entity_context(self, entity_context: Dict[str, Any]) -> str:
+        """Format entity context for inclusion in prompts.
+
+        Args:
+            entity_context: Dict with 'entities' and 'relationships'.
+
+        Returns:
+            Formatted string describing entities and their relationships.
+        """
+        parts = []
+
+        entities = entity_context.get('entities', [])
+        relationships = entity_context.get('relationships', [])
+
+        if entities:
+            parts.append("RELATED CONCEPTS:")
+            for entity in entities[:10]:  # Limit to top 10 entities
+                name = entity.get('name', '')
+                entity_type = entity.get('type', 'concept')
+                description = entity.get('description', '')
+                if description:
+                    parts.append(f"- {name} ({entity_type}): {description}")
+                else:
+                    parts.append(f"- {name} ({entity_type})")
+
+        if relationships:
+            parts.append("\nRELATIONSHIPS:")
+            for rel in relationships[:10]:  # Limit to top 10 relationships
+                source = rel.get('source', '')
+                target = rel.get('target', '')
+                rel_type = rel.get('type', 'related_to')
+                parts.append(f"- {source} {rel_type.replace('_', ' ')} {target}")
+
+        return '\n'.join(parts)
+
     def build_context(self, chunks: List[Dict[str, Any]],
                       include_headings: bool = False,
                       include_sources: bool = False,
@@ -182,6 +274,71 @@ class ContextBuilder:
             chunks,
             include_headings=True,
             include_sources=True
+        )
+
+        return f"""Based on the following documentation context, answer the question.
+
+CONTEXT:
+{context}
+
+QUESTION: {query}
+
+Provide a clear, accurate answer based only on the context provided."""
+
+    def build_context_with_knowledge_graph(self, chunks: List[Dict[str, Any]],
+                                            include_headings: bool = True,
+                                            include_sources: bool = True,
+                                            include_entities: bool = True) -> str:
+        """Build context string including knowledge graph information.
+
+        Args:
+            chunks: List of chunk dicts with 'id'.
+            include_headings: Whether to include heading paths.
+            include_sources: Whether to include source info.
+            include_entities: Whether to include entity context.
+
+        Returns:
+            Combined context string with optional entity information.
+        """
+        # Build base context
+        base_context = self.build_context(
+            chunks,
+            include_headings=include_headings,
+            include_sources=include_sources
+        )
+
+        if not include_entities:
+            return base_context
+
+        # Get entity context
+        chunk_ids = [c.get('id') for c in chunks if c.get('id')]
+        entity_context = self.get_entity_context(chunk_ids)
+
+        # Format and append entity context if available
+        if entity_context.get('entities') or entity_context.get('relationships'):
+            entity_str = self.format_entity_context(entity_context)
+            return f"{base_context}\n\n---\n\n{entity_str}"
+
+        return base_context
+
+    def build_rich_prompt_context(self, query: str,
+                                   chunks: List[Dict[str, Any]],
+                                   include_entities: bool = True) -> str:
+        """Build context formatted for prompts with knowledge graph info.
+
+        Args:
+            query: Original query.
+            chunks: List of chunk dicts.
+            include_entities: Whether to include entity context.
+
+        Returns:
+            Prompt-ready context string with optional entity information.
+        """
+        context = self.build_context_with_knowledge_graph(
+            chunks,
+            include_headings=True,
+            include_sources=True,
+            include_entities=include_entities
         )
 
         return f"""Based on the following documentation context, answer the question.


### PR DESCRIPTION
## Summary

The knowledge graph (entities and relationships) existed but was **not being used** during answer generation. This adds methods to ContextBuilder to include entity context in prompts for richer, more contextual answers.

## How It Works

1. When building context, optionally fetch entities linked to retrieved chunks
2. Fetch relationships between those entities
3. Format and append to context as a "RELATED CONCEPTS" section

## Changes
- Added `get_entity_context()` - retrieves entities for given chunks
- Added `format_entity_context()` - formats entities/relationships for prompts
- Added `build_context_with_knowledge_graph()` - context with optional KG info
- Added `build_rich_prompt_context()` - prompt builder with KG support

## Usage
```python
from rag_system.query.context_builder import ContextBuilder

builder = ContextBuilder(db_path)

# Build context with knowledge graph info
context = builder.build_context_with_knowledge_graph(chunks, include_entities=True)

# Or build a complete prompt
prompt = builder.build_rich_prompt_context(query, chunks, include_entities=True)
```

## Output Example
```
[Chunk content here...]

---

RELATED CONCEPTS:
- ConfigManager (system): Manages all configuration settings
- TimeoutHandler (process): Handles timeout events

RELATIONSHIPS:
- ConfigManager configures TimeoutHandler
- TimeoutHandler depends on ConfigManager
```

Closes #28