### PR TITLE
feat: Add missing CLI commands

### DIFF
--- a/rag_system/main.py
+++ b/rag_system/main.py
@@ -215,6 +215,34 @@ def create_parser() -> argparse.ArgumentParser:
         help='Output results as JSON'
     )
 
+    # Export knowledge graph command
+    export_graph_parser = subparsers.add_parser(
+        'export-graph',
+        help='Export knowledge graph as JSON'
+    )
+    export_graph_parser.add_argument(
+        '--output', '-o', type=str, metavar='FILE',
+        help='Output file path (default: stdout)'
+    )
+    export_graph_parser.add_argument(
+        '--pretty', action='store_true',
+        help='Pretty-print JSON output'
+    )
+
+    # Validate database command
+    validate_parser = subparsers.add_parser(
+        'validate',
+        help='Validate database integrity'
+    )
+    validate_parser.add_argument(
+        '--fix', action='store_true',
+        help='Attempt to fix issues (where possible)'
+    )
+    validate_parser.add_argument(
+        '--json', action='store_true',
+        help='Output results as JSON'
+    )
+
     # Stats command
     subparsers.add_parser('stats', help='Show system statistics')
 
@@ -1204,6 +1232,157 @@ def main() -> None:
                     print(f"Errors: {len(stats['errors'])}")
                     for error in stats['errors'][:5]:
                         print(f"  - {error}")
+
+        elif args.command == 'export-graph':
+            import json as json_module
+
+            conn = get_connection(args.db)
+            try:
+                # Get all entities
+                cursor = conn.execute("SELECT * FROM entities")
+                entities = [dict(row) for row in cursor.fetchall()]
+
+                # Get all relationships
+                cursor = conn.execute("""
+                    SELECT r.*, 
+                           e1.name as source_name, 
+                           e2.name as target_name
+                    FROM relationships r
+                    JOIN entities e1 ON r.source_entity_id = e1.id
+                    JOIN entities e2 ON r.target_entity_id = e2.id
+                """)
+                relationships = [dict(row) for row in cursor.fetchall()]
+
+                graph = {
+                    'entities': entities,
+                    'relationships': relationships,
+                    'stats': {
+                        'entity_count': len(entities),
+                        'relationship_count': len(relationships)
+                    }
+                }
+
+                indent = 2 if args.pretty else None
+                json_output = json_module.dumps(graph, indent=indent)
+
+                if args.output:
+                    with open(args.output, 'w') as f:
+                        f.write(json_output)
+                    print(f"Knowledge graph exported to {args.output}")
+                    print(f"  Entities: {len(entities)}")
+                    print(f"  Relationships: {len(relationships)}")
+                else:
+                    print(json_output)
+
+            finally:
+                conn.close()
+
+        elif args.command == 'validate':
+            import json as json_module
+
+            conn = get_connection(args.db)
+            issues = []
+            fixes_applied = []
+
+            try:
+                # Check 1: Orphaned chunks (no page)
+                cursor = conn.execute("""
+                    SELECT COUNT(*) as count FROM chunks c
+                    LEFT JOIN pages p ON c.page_id = p.id
+                    WHERE p.id IS NULL
+                """)
+                orphaned_chunks = cursor.fetchone()['count']
+                if orphaned_chunks > 0:
+                    issues.append({
+                        'type': 'orphaned_chunks',
+                        'count': orphaned_chunks,
+                        'description': f'{orphaned_chunks} chunks have no associated page'
+                    })
+                    if args.fix:
+                        conn.execute("""
+                            DELETE FROM chunks WHERE page_id NOT IN (SELECT id FROM pages)
+                        """)
+                        conn.commit()
+                        fixes_applied.append(f'Deleted {orphaned_chunks} orphaned chunks')
+
+                # Check 2: Chunks without embeddings (when AI is enabled)
+                if config.AI_ENABLED:
+                    cursor = conn.execute(
+                        "SELECT COUNT(*) as count FROM chunks WHERE embedding_json IS NULL"
+                    )
+                    missing_embeddings = cursor.fetchone()['count']
+                    if missing_embeddings > 0:
+                        issues.append({
+                            'type': 'missing_embeddings',
+                            'count': missing_embeddings,
+                            'description': f'{missing_embeddings} chunks are missing embeddings'
+                        })
+
+                # Check 3: Pages without summaries
+                cursor = conn.execute(
+                    "SELECT COUNT(*) as count FROM pages WHERE summary IS NULL OR summary = ''"
+                )
+                missing_summaries = cursor.fetchone()['count']
+                if missing_summaries > 0:
+                    issues.append({
+                        'type': 'missing_summaries',
+                        'count': missing_summaries,
+                        'description': f'{missing_summaries} pages are missing summaries'
+                    })
+
+                # Check 4: BM25 index consistency
+                from rag_system.database import get_corpus_stats
+                corpus_stats = get_corpus_stats(conn)
+                cursor = conn.execute("SELECT COUNT(*) as count FROM chunks")
+                total_chunks = cursor.fetchone()['count']
+                if corpus_stats:
+                    indexed_docs = corpus_stats.get('total_docs', 0)
+                    if indexed_docs != total_chunks:
+                        issues.append({
+                            'type': 'bm25_index_mismatch',
+                            'indexed': indexed_docs,
+                            'actual': total_chunks,
+                            'description': f'BM25 index has {indexed_docs} docs but {total_chunks} chunks exist'
+                        })
+                        if args.fix:
+                            from rag_system.search.bm25_search import BM25Index
+                            bm25_index = BM25Index(args.db)
+                            bm25_index.build()
+                            fixes_applied.append('Rebuilt BM25 index')
+
+                # Check 5: Database integrity
+                cursor = conn.execute("PRAGMA integrity_check")
+                integrity = cursor.fetchone()[0]
+                if integrity != 'ok':
+                    issues.append({
+                        'type': 'integrity_error',
+                        'description': f'SQLite integrity check failed: {integrity}'
+                    })
+
+                result = {
+                    'valid': len(issues) == 0,
+                    'issues': issues,
+                    'fixes_applied': fixes_applied
+                }
+
+                if args.json:
+                    print(json_module.dumps(result, indent=2))
+                else:
+                    if result['valid']:
+                        print("Database validation: PASSED")
+                        print("No issues found.")
+                    else:
+                        print("Database validation: ISSUES FOUND")
+                        print("=" * 40)
+                        for issue in issues:
+                            print(f"- [{issue['type']}] {issue['description']}")
+                        if fixes_applied:
+                            print("\nFixes applied:")
+                            for fix in fixes_applied:
+                                print(f"  - {fix}")
+
+            finally:
+                conn.close()
 
         elif args.command == 'backfill':
             if not rag.vector_client:


### PR DESCRIPTION
## Summary

Adds the missing CLI commands documented in PROJECT.md.

## New Commands

### export-graph
Exports the knowledge graph (entities and relationships) as JSON.

```bash
# Output to stdout
python -m rag_system.main export-graph

# Save to file with pretty-printing
python -m rag_system.main export-graph -o graph.json --pretty
```

### validate
Validates database integrity and optionally fixes issues.

```bash
# Check for issues
python -m rag_system.main validate

# Auto-fix issues where possible
python -m rag_system.main validate --fix

# Output as JSON
python -m rag_system.main validate --json
```

**Validation checks:**
- Orphaned chunks (chunks with no associated page)
- Missing embeddings (when AI is enabled)
- Missing page summaries
- BM25 index consistency
- SQLite integrity check

## Already Existing Commands
Some commands from the issue already exist:
- `rebuild-summaries` — Added in #27
- `clear-cache` — Exists as `cache clear`
- `index-rebuild` — Exists as `rebuild-index`

Closes #29